### PR TITLE
Strip all filename and position info when -tiny is passed

### DIFF
--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -162,21 +162,24 @@ func stripPCLinesAndNames(am *goobj2.ArchiveMember) {
 	lists := [][]*goobj2.Sym{am.SymDefs, am.NonPkgSymDefs, am.NonPkgSymRefs}
 	for _, list := range lists {
 		for _, s := range list {
-			if s.Func != nil {
-				for _, inl := range s.Func.InlTree {
-					inl.Line = 1
-				}
-
-				s.Func.PCFile = nil
-				s.Func.PCLine = nil
-				s.Func.PCInline = nil
-
-				// remove unneeded debug aux symbols
-				s.Func.DwarfInfo = nil
-				s.Func.DwarfLoc = nil
-				s.Func.DwarfRanges = nil
-				s.Func.DwarfDebugLines = nil
+			if s.Func == nil {
+				continue
 			}
+
+			for _, inl := range s.Func.InlTree {
+				inl.Line = 1
+			}
+
+			s.Func.PCFile = nil
+			s.Func.PCLine = nil
+			s.Func.PCInline = nil
+
+			// remove unneeded debug aux symbols
+			s.Func.DwarfInfo = nil
+			s.Func.DwarfLoc = nil
+			s.Func.DwarfRanges = nil
+			s.Func.DwarfDebugLines = nil
+
 		}
 	}
 

--- a/line_obfuscator.go
+++ b/line_obfuscator.go
@@ -96,11 +96,6 @@ func transformLineInfo(file *ast.File) ([]string, *ast.File) {
 			return true
 		}
 
-		if envGarbleTiny {
-			funcDecl.Doc = prependComment(funcDecl.Doc, &ast.Comment{Text: "//line :1"})
-			return true
-		}
-
 		comment := &ast.Comment{Text: fmt.Sprintf("//line %c.go:%d", nameCharset[mathrand.Intn(len(nameCharset))], 1+newLines[funcCounter])}
 		funcDecl.Doc = prependComment(funcDecl.Doc, comment)
 		funcCounter++

--- a/main.go
+++ b/main.go
@@ -548,7 +548,9 @@ func transformCompile(args []string) ([]string, error) {
 			// messy.
 			name = "_cgo_" + name
 		default:
-			extraComments, file = transformLineInfo(file)
+			if !envGarbleTiny {
+				extraComments, file = transformLineInfo(file)
+			}
 			file = transformGo(file, info, blacklist)
 
 			// Uncomment for some quick debugging. Do not delete.

--- a/testdata/scripts/asm.txt
+++ b/testdata/scripts/asm.txt
@@ -7,6 +7,11 @@ binsubstr main$exe 'privateAdd' 'PublicAdd'
 
 [short] stop # no need to verify this with -short
 
+garble -tiny build
+exec ./main
+cmp stderr main.stderr
+binsubstr main$exe 'privateAdd' 'PublicAdd'
+
 go build
 exec ./main
 cmp stderr main.stderr

--- a/testdata/scripts/cgo.txt
+++ b/testdata/scripts/cgo.txt
@@ -7,6 +7,11 @@ binsubstr main$exe 'privateAdd'
 
 [short] stop # no need to verify this with -short
 
+garble -tiny build
+exec ./main
+cmp stderr main.stderr
+binsubstr main$exe 'privateAdd'
+
 go build
 exec ./main
 cmp stderr main.stderr

--- a/testdata/scripts/tiny.txt
+++ b/testdata/scripts/tiny.txt
@@ -1,7 +1,7 @@
 env GOPRIVATE=test/main
 
 # Tiny mode
-garble -tiny -debugdir=.obf-src build
+garble -tiny build
 exec ./main$exe
 stderr '\? 0'
 

--- a/testdata/scripts/tiny.txt
+++ b/testdata/scripts/tiny.txt
@@ -3,7 +3,6 @@ env GOPRIVATE=test/main
 # Tiny mode
 garble -tiny -debugdir=.obf-src build
 exec ./main$exe
-
 stderr '\? 0'
 
 [short] stop # no need to verify this with -short

--- a/testdata/scripts/tiny.txt
+++ b/testdata/scripts/tiny.txt
@@ -1,43 +1,33 @@
 env GOPRIVATE=test/main
 
-env TINY_PATTERN='^\/\/line :1$'
-env DEFAULT_PATTERN='^\/\/line \w\.go:[1-9][0-9]*$'
-env DEFAULT_STACK_PATTERN='^\t\w\.go:[1-9][0-9]*(\s\+0x[0-9a-f]+)?'
-env TINY_STACK_PATTERN='^\t\?\?:[0-9][0-9]*(\s\+0x[0-9a-f]+)?$'
-
 # Tiny mode
 garble -tiny -debugdir=.obf-src build
+exec ./main$exe
 
-grep $TINY_PATTERN .obf-src/main/main.go
-! grep $DEFAULT_PATTERN .obf-src/main/main.go
-
-! exec ./main$exe
-! stderr 'main\.go'
-! stderr $DEFAULT_STACK_PATTERN
-stderr $TINY_STACK_PATTERN
+stderr '\? 0'
 
 [short] stop # no need to verify this with -short
 
 # Default mode
-
 garble -debugdir=.obf-src build
 
 # Check for file name leak protection
-grep $TINY_PATTERN .obf-src/main/main.go
+grep '^\/\/line :1$' .obf-src/main/main.go
 
 # Check for default line obfuscation
-grep $DEFAULT_PATTERN .obf-src/main/main.go
+grep '^\/\/line \w\.go:[1-9][0-9]*$' .obf-src/main/main.go
+exec ./main$exe
 
-! exec ./main$exe
-! stderr 'main\.go'
-! stderr $TINY_STACK_PATTERN
-stderr $DEFAULT_STACK_PATTERN
+stderr '\w\.go 3'
 
 -- go.mod --
 module test/main
 -- main.go --
 package main
 
+import "runtime"
+
 func main() {
-	panic("Test")
+	_, file, line, _ := runtime.Caller(0)
+	println(file, line)
 }

--- a/testdata/scripts/tiny.txt
+++ b/testdata/scripts/tiny.txt
@@ -18,7 +18,7 @@ grep '^\/\/line :1$' .obf-src/main/main.go
 grep '^\/\/line \w\.go:[1-9][0-9]*$' .obf-src/main/main.go
 exec ./main$exe
 
-stderr '\w\.go 3'
+stderr '\w\.go [1-9]'
 
 -- go.mod --
 module test/main


### PR DESCRIPTION
Updates #127. 

`honnef.co/go/tools/cmd/staticcheck` with and without `-tiny`:

```
normal        8167424
with -tiny    7581696
```

That's a ~7% decrease in size.