### PR TITLE
set up an AUTHORS file to attribute copyright

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,10 +42,11 @@ jobs:
       run: |
         go version
         go test ./...
+
   code-checks:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Test that only LF line endings are used
-      run: bash crlf_test.sh
+      run: ./scripts/crlf-test.sh

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,14 @@
+# This is the official list of Garble authors for copyright purposes.
+
+# Names should be added to this file as one of
+#     Organization's name
+#     Individual's name <submission email address>
+
+# Please keep the list sorted.
+
+Andrew LeFevre <jalefevre@liberty.edu>
+Daniel Martí <mvdan@mvdan.cc>
+Nicholas Jones <me@nicholasjon.es>
+Zachary Wasserman <zachwass2000@gmail.com>
+lu4p <lu4p@pm.me>
+pagran <pagran@protonmail.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,9 @@ Thank you for your interest in contributing! Here are some ground rules:
 3. All contributions are done in PRs with at least one review and CI
 4. We use the `#obfuscation` channel over at the [Gophers Slack](https://invite.slack.golangbridge.org/) to chat
 
+When contributing for the first time, you should also add yourself to the
+[AUTHORS file](AUTHORS).
+
 ### Testing
 
 Just the usual `go test ./...`; many of the tests are in

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019, Daniel Martí. All rights reserved.
+Copyright (c) 2019, The Garble Authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2020, Daniel Martí <mvdan@mvdan.cc>
-// See LICENSE for licensing information
+// Copyright (c) 2020, The Garble Authors.
+// See LICENSE for licensing information.
 
 package main
 

--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, The Garble Authors.
+// See LICENSE for licensing information.
+
 package main
 
 import (

--- a/internal/asthelper/asthelper.go
+++ b/internal/asthelper/asthelper.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, The Garble Authors.
+// See LICENSE for licensing information.
+
 package asthelper
 
 import (

--- a/internal/literals/literals.go
+++ b/internal/literals/literals.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, The Garble Authors.
+// See LICENSE for licensing information.
+
 package literals
 
 import (

--- a/internal/literals/obfuscators.go
+++ b/internal/literals/obfuscators.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, The Garble Authors.
+// See LICENSE for licensing information.
+
 package literals
 
 import (

--- a/internal/literals/seed.go
+++ b/internal/literals/seed.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, The Garble Authors.
+// See LICENSE for licensing information.
+
 package literals
 
 import (

--- a/internal/literals/shuffle.go
+++ b/internal/literals/shuffle.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, The Garble Authors.
+// See LICENSE for licensing information.
+
 package literals
 
 import (

--- a/internal/literals/simple.go
+++ b/internal/literals/simple.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, The Garble Authors.
+// See LICENSE for licensing information.
+
 package literals
 
 import (

--- a/internal/literals/split.go
+++ b/internal/literals/split.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, The Garble Authors.
+// See LICENSE for licensing information.
+
 package literals
 
 import (

--- a/internal/literals/swap.go
+++ b/internal/literals/swap.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, The Garble Authors.
+// See LICENSE for licensing information.
+
 package literals
 
 import (

--- a/line_obfuscator.go
+++ b/line_obfuscator.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, The Garble Authors.
+// See LICENSE for licensing information.
+
 package main
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2019, Daniel Martí <mvdan@mvdan.cc>
-// See LICENSE for licensing information
+// Copyright (c) 2019, The Garble Authors.
+// See LICENSE for licensing information.
 
 package main
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2019, Daniel Martí <mvdan@mvdan.cc>
-// See LICENSE for licensing information
+// Copyright (c) 2019, The Garble Authors.
+// See LICENSE for licensing information.
 
 package main
 

--- a/runtime_api.go
+++ b/runtime_api.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, The Garble Authors.
+// See LICENSE for licensing information.
+
 package main
 
 import (

--- a/scripts/crlf-test.sh
+++ b/scripts/crlf-test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 if \
 	grep \
 		--recursive \

--- a/scripts/ensure-copyrights.sh
+++ b/scripts/ensure-copyrights.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+for f in $(git ls-files '*.go'); do
+	if ! grep -q Copyright $f; then
+		sed -i '1i\
+// Copyright (c) 2020, The Garble Authors.\
+// See LICENSE for licensing information.\
+
+' $f
+	fi
+done

--- a/testdata/bench/main.go
+++ b/testdata/bench/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, The Garble Authors.
+// See LICENSE for licensing information.
+
 package main
 
 import "fmt"


### PR DESCRIPTION
Many files were missing copyright, so also add a short script to add the
missing lines with the current year, and run it.

The AUTHORS file is also self-explanatory. Contributors can add
themselves there, or we can simply update it from time to time via
git-shortlog.

Since we have two scripts now, set up a directory for them.