### PR TITLE
all: fix links after moving repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ to document the current shortcomings of this tool.
 * Functions implemented outside Go, such as assembly, aren't garbled since we
   currently only transform the input Go source.
 
-* Go plugins are not currently supported; see [#87](https://github.com/mvdan/garble/issues/87).
+* Go plugins are not currently supported; see [#87](https://github.com/burrowers/garble/issues/87).
 
 ### Runtime API
 

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ garble accepts the following flags:
 	flagSet.PrintDefaults()
 	fmt.Fprintf(os.Stderr, `
 
-For more information, see https://github.com/mvdan/garble.
+For more information, see https://github.com/burrowers/garble.
 `[1:])
 	os.Exit(2)
 }


### PR DESCRIPTION
A couple of places still linked to the personal repo.