### PR TITLE
Rewrite renaming logic for private names and reduce length of public names

### DIFF
--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -6,10 +6,9 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
+	"encoding/gob"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -49,8 +48,7 @@ type privateImports struct {
 }
 
 func appendPrivateNameMap(nameMap map[string]string, packageDirectory string) error {
-	mapFile := filepath.Join(packageDirectory, garbleMapFile)
-	data, err := ioutil.ReadFile(mapFile)
+	file, err := os.Open(filepath.Join(packageDirectory, garbleMapFile))
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
@@ -59,7 +57,7 @@ func appendPrivateNameMap(nameMap map[string]string, packageDirectory string) er
 	}
 
 	var localMap map[string]string
-	if err = json.Unmarshal(data, &localMap); err != nil {
+	if err = gob.NewDecoder(file).Decode(&localMap); err != nil {
 		return err
 	}
 

--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -6,8 +6,12 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -44,17 +48,42 @@ type privateImports struct {
 	privateNames []string
 }
 
-func obfuscateImports(objPath, importCfgPath string) (map[string]string, error) {
+func appendPrivateNameMap(nameMap map[string]string, pkg string, packageDirectory string) error {
+	mapFile := filepath.Join(packageDirectory, garbleMapFile)
+	data, err := ioutil.ReadFile(mapFile)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	var localMap map[string]string
+	err = json.Unmarshal(data, &localMap)
+	if err != nil {
+		return err
+	}
+
+	for oldName, newName := range localMap {
+		nameMap[pkg+"."+oldName] = newName
+	}
+
+	return nil
+}
+
+func obfuscateImports(objPath, importCfgPath string) (map[string]string, map[string]string, error) {
 	importCfg, err := goobj2.ParseImportCfg(importCfgPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	mainPkg, err := goobj2.Parse(objPath, "main", importCfg)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing main objfile: %v", err)
+		return nil, nil, fmt.Errorf("error parsing main objfile: %v", err)
 	}
 	pkgs := []pkgInfo{{mainPkg, objPath, true}}
 
+	nameMap := make(map[string]string)
 	// build list of imported packages that are private
 	for pkgPath, info := range importCfg {
 		// if the '-tiny' flag is passed, we will strip filename
@@ -62,10 +91,16 @@ func obfuscateImports(objPath, importCfgPath string) (map[string]string, error) 
 		if private := isPrivate(pkgPath); envGarbleTiny || private {
 			pkg, err := goobj2.Parse(info.Path, pkgPath, importCfg)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing objfile %s at %s: %v", pkgPath, info.Path, err)
+				return nil, nil, fmt.Errorf("error parsing objfile %s at %s: %v", pkgPath, info.Path, err)
 			}
 
 			pkgs = append(pkgs, pkgInfo{pkg, info.Path, private})
+
+			packageDir := filepath.Dir(info.Path)
+			err = appendPrivateNameMap(nameMap, pkgPath, packageDir)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error parsing name map %s at %s: %v", pkgPath, info.Path, err)
+			}
 		}
 	}
 
@@ -147,16 +182,16 @@ func obfuscateImports(objPath, importCfgPath string) (map[string]string, error) 
 		}
 
 		if err := p.pkg.Write(p.path); err != nil {
-			return nil, fmt.Errorf("error writing objfile %s at %s: %v", p.pkg.ImportPath, p.path, err)
+			return nil, nil, fmt.Errorf("error writing objfile %s at %s: %v", p.pkg.ImportPath, p.path, err)
 		}
 	}
 
 	// garble importcfg so the linker knows where to find garbled imports
 	if err := garbleImportCfg(importCfgPath, importCfg, garbledImports); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return garbledImports, nil
+	return garbledImports, nameMap, nil
 }
 
 // stripPCLinesAndNames removes all filename and position info

--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -74,7 +74,7 @@ func obfuscateImports(objPath, importCfgPath string) (garbledImports, privateNam
 	}
 	pkgs := []pkgInfo{{mainPkg, objPath, true}}
 
-	nameMap := make(map[string]string)
+	privateNameMap = make(map[string]string)
 	// build list of imported packages that are private
 	for pkgPath, info := range importCfg {
 		// if the '-tiny' flag is passed, we will strip filename
@@ -88,7 +88,7 @@ func obfuscateImports(objPath, importCfgPath string) (garbledImports, privateNam
 			pkgs = append(pkgs, pkgInfo{pkg, info.Path, private})
 
 			packageDir := filepath.Dir(info.Path)
-			if err := appendPrivateNameMap(nameMap, packageDir); err != nil {
+			if err := appendPrivateNameMap(privateNameMap, packageDir); err != nil {
 				return nil, nil, fmt.Errorf("error parsing name map %s at %s: %v", pkgPath, info.Path, err)
 			}
 		}
@@ -182,7 +182,7 @@ func obfuscateImports(objPath, importCfgPath string) (garbledImports, privateNam
 		return nil, nil, err
 	}
 
-	return garbledImports, nameMap, nil
+	return garbledImports, privateNameMap, nil
 }
 
 // stripPCLinesAndNames removes all filename and position info

--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -6,7 +6,7 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"encoding/gob"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -55,16 +55,9 @@ func appendPrivateNameMap(nameMap map[string]string, packageDirectory string) er
 	if err != nil {
 		return err
 	}
-
-	var localMap map[string]string
-	if err = gob.NewDecoder(file).Decode(&localMap); err != nil {
+	if err := json.NewDecoder(file).Decode(&nameMap); err != nil {
 		return err
 	}
-
-	for oldName, newName := range localMap {
-		nameMap[oldName] = newName
-	}
-
 	return nil
 }
 
@@ -93,7 +86,7 @@ func obfuscateImports(objPath, importCfgPath string) (garbledImports, privateNam
 			pkgs = append(pkgs, pkgInfo{pkg, info.Path, private})
 
 			packageDir := filepath.Dir(info.Path)
-			if err = appendPrivateNameMap(nameMap, packageDir); err != nil {
+			if err := appendPrivateNameMap(nameMap, packageDir); err != nil {
 				return nil, nil, fmt.Errorf("error parsing name map %s at %s: %v", pkgPath, info.Path, err)
 			}
 		}

--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -55,6 +55,8 @@ func appendPrivateNameMap(nameMap map[string]string, packageDirectory string) er
 	if err != nil {
 		return err
 	}
+	defer file.Close()
+
 	if err := json.NewDecoder(file).Decode(&nameMap); err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -607,7 +607,7 @@ func transformCompile(args []string) ([]string, error) {
 		}
 		defer file.Close()
 
-		if err := gob.NewEncoder(file).Encode(privateNameMap); err != nil {
+		if err := json.NewEncoder(file).Encode(privateNameMap); err != nil {
 			return nil, err
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -600,12 +600,14 @@ func transformCompile(args []string) ([]string, error) {
 
 	if len(privateNameMap) > 0 {
 		outputDirectory := filepath.Dir(flagValue(flags, "-o"))
-		data, err := json.Marshal(privateNameMap)
+
+		file, err := os.Create(filepath.Join(outputDirectory, garbleMapFile))
 		if err != nil {
 			return nil, err
 		}
+		defer file.Close()
 
-		if err := ioutil.WriteFile(filepath.Join(outputDirectory, garbleMapFile), data, 0644); err != nil {
+		if err := gob.NewEncoder(file).Encode(privateNameMap); err != nil {
 			return nil, err
 		}
 	}

--- a/testdata/scripts/ldflags.txt
+++ b/testdata/scripts/ldflags.txt
@@ -1,12 +1,17 @@
 # Note the proper domain, since the dot adds an edge case.
 env GOPRIVATE=domain.test/main
 
-garble -tiny build -ldflags='-X=main.unexportedVersion=v1.0.0 -X=domain.test/main/imported.ExportedVar=replaced'
+garble build -ldflags='-X=main.unexportedVersion=v1.0.0 -X=domain.test/main/imported.ExportedVar=replaced'
 exec ./main
 cmp stderr main.stderr
 ! binsubstr main$exe 'unexportedVersion'
 
 [short] stop # no need to verify this with -short
+
+garble -tiny build -ldflags='-X=main.unexportedVersion=v1.0.0 -X=domain.test/main/imported.ExportedVar=replaced'
+exec ./main
+cmp stderr main.stderr
+! binsubstr main$exe 'unexportedVersion'
 
 exec go build -ldflags='-X=main.unexportedVersion=v1.0.0 -X=domain.test/main/imported.ExportedVar=replaced'
 exec ./main

--- a/testdata/scripts/ldflags.txt
+++ b/testdata/scripts/ldflags.txt
@@ -1,7 +1,7 @@
 # Note the proper domain, since the dot adds an edge case.
 env GOPRIVATE=domain.test/main
 
-garble build -ldflags='-X=main.unexportedVersion=v1.0.0 -X=domain.test/main/imported.ExportedVar=replaced'
+garble -tiny build -ldflags='-X=main.unexportedVersion=v1.0.0 -X=domain.test/main/imported.ExportedVar=replaced'
 exec ./main
 cmp stderr main.stderr
 ! binsubstr main$exe 'unexportedVersion'


### PR DESCRIPTION
- Reduced hash size to 4
- Reducing the length of private names by using a counter per package