### PR TITLE
testdata: use the debugdir flag less often

### DIFF
--- a/testdata/scripts/literals.txt
+++ b/testdata/scripts/literals.txt
@@ -49,7 +49,6 @@ grep '^\s+\w+ = append\(\w+,(\s+\w+\[\d+\][\^\-+]\w+\[\d+\],?)+\)$' .obf-src/mai
 # XorSeed obfuscator. Detect type decFunc func(byte) decFunc
 grep '^\s+type \w+ func\(byte\) \w+$' .obf-src/main/extraLiterals.go
 
-
 -- go.mod --
 module test/main
 -- main.go --

--- a/testdata/scripts/syntax.txt
+++ b/testdata/scripts/syntax.txt
@@ -1,12 +1,10 @@
 env GOPRIVATE='test/main,rsc.io/*'
 
-garble -debugdir=debug build
+garble build
 exec ./main$exe
 cmp stderr main.stderr
 
 ! binsubstr main$exe 'localName' 'globalConst' 'globalVar' 'globalType' 'valuable information' 'rsc.io'
-
-binsubstr debug/main/scopes.go 'localName' 'globalConst'
 
 [short] stop # no need to verify this with -short
 

--- a/testdata/scripts/tiny.txt
+++ b/testdata/scripts/tiny.txt
@@ -11,13 +11,7 @@ stderr '\? 0'
 
 # Default mode
 env GODEBUG=
-garble -debugdir=.obf-src build
-
-# Check for file name leak protection
-grep '^\/\/line :1$' .obf-src/main/main.go
-
-# Check for default line obfuscation
-grep '^\/\/line \w\.go:[1-9][0-9]*$' .obf-src/main/main.go
+garble build
 ! exec ./main$exe
 cmp stdout main.stdout
 stderr '\w\.go [1-9]'


### PR DESCRIPTION
In tiny.txt, we already check line numbers via stderr, so there's no
need to do that via -debugdir.

In syntax.txt, we only really care about what names remain in the
binary, not the names which remain in the source but don't affect the
binary.

These changes are important because -debugdir adds a non-trivial amount
of work, which will impede build caching once that feature lands. We
will likely make -debugdir support build caching eventually, but for
now, this preliminary change will make 'go test' much faster with build
caching.

And of course, the tests get simpler, which is nice.
