### PR TITLE
Remove unused constant and fix magic number

### DIFF
--- a/line_obfuscator.go
+++ b/line_obfuscator.go
@@ -12,11 +12,9 @@ import (
 	"golang.org/x/tools/go/ast/astutil"
 )
 
-const (
-	// PosMin is the smallest correct value for the line number.
-	// Source: https://go.googlesource.com/go/+/refs/heads/master/src/cmd/compile/internal/syntax/parser_test.go#229
-	PosMin = 1
-)
+// PosMin is the smallest correct value for the line number.
+// Source: https://go.googlesource.com/go/+/refs/heads/master/src/cmd/compile/internal/syntax/parser_test.go#229
+const PosMin = 1
 
 func prependComment(group *ast.CommentGroup, comment *ast.Comment) *ast.CommentGroup {
 	if group == nil {

--- a/line_obfuscator.go
+++ b/line_obfuscator.go
@@ -13,10 +13,6 @@ import (
 )
 
 const (
-	// PosMax is the largest line or column value that can be represented without loss.
-	// Source: https://go.googlesource.com/go/+/refs/heads/master/src/cmd/compile/internal/syntax/pos.go#11
-	PosMax = 1 << 30
-
 	// PosMin is the smallest correct value for the line number.
 	// Source: https://go.googlesource.com/go/+/refs/heads/master/src/cmd/compile/internal/syntax/parser_test.go#229
 	PosMin = 1
@@ -99,7 +95,7 @@ func transformLineInfo(file *ast.File) ([]string, *ast.File) {
 			return true
 		}
 
-		comment := &ast.Comment{Text: fmt.Sprintf("//line %c.go:%d", nameCharset[mathrand.Intn(len(nameCharset))], 1+newLines[funcCounter])}
+		comment := &ast.Comment{Text: fmt.Sprintf("//line %c.go:%d", nameCharset[mathrand.Intn(len(nameCharset))], PosMin+newLines[funcCounter])}
 		funcDecl.Doc = prependComment(funcDecl.Doc, comment)
 		funcCounter++
 		return true


### PR DESCRIPTION
Removed PosMax constant as it is no longer needed after optimization (https://github.com/burrowers/garble/commit/b3f04e53d0765e44a0fa99ffefae8a90564e928d) of line obfuscation.

Replaced the magic number with PosMin
