### PR TITLE
rewrite private name map storage to support build caching

### DIFF
--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -52,7 +52,8 @@ func appendPrivateNameMap(pkg *goobj2.Package, nameMap map[string]string) error 
 		}
 
 		serializedMap := member.ArchiveHeader.Data
-		if err := json.Unmarshal(serializedMap[:bytes.IndexByte(serializedMap, 0x00)], &nameMap); err != nil {
+		serializedMap = serializedMap[:bytes.IndexByte(serializedMap, 0x00)]
+		if err := json.Unmarshal(serializedMap, &nameMap); err != nil {
 			return err
 		}
 		return nil

--- a/main.go
+++ b/main.go
@@ -31,6 +31,8 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/Binject/debug/goobj2"
+
 	"golang.org/x/mod/module"
 	"golang.org/x/mod/semver"
 	"golang.org/x/tools/go/ast/astutil"
@@ -115,7 +117,7 @@ var (
 	seed []byte
 )
 
-const garbleMapFile = "garble.map"
+const garbleMapHeaderName = "garble/nameMap"
 
 func saveListedPackages(w io.Writer, flags, patterns []string) error {
 	args := []string{"list", "-json", "-deps", "-export"}
@@ -664,17 +666,34 @@ func transformCompile(args []string) ([]string, error) {
 	}
 
 	if len(privateNameMap) > 0 {
-		outputDirectory := filepath.Dir(flagValue(flags, "-o"))
+		objPath := flagValue(flags, "-o")
+		importcfg := flagValue(flags, "-importcfg")
+		deferred = append(deferred, func() error {
+			importCfg, err := goobj2.ParseImportCfg(importcfg)
+			if err != nil {
+				return err
+			}
 
-		file, err := os.Create(filepath.Join(outputDirectory, garbleMapFile))
-		if err != nil {
-			return nil, err
-		}
-		defer file.Close()
+			pkg, err := goobj2.Parse(objPath, pkgPath, importCfg)
+			if err != nil {
+				return err
+			}
 
-		if err := json.NewEncoder(file).Encode(privateNameMap); err != nil {
-			return nil, err
-		}
+			data, err := json.Marshal(privateNameMap)
+			if err != nil {
+				return err
+			}
+
+			pkg.ArchiveMembers = append(pkg.ArchiveMembers, goobj2.ArchiveMember{
+				ArchiveHeader: goobj2.ArchiveHeader{
+					Name: garbleMapHeaderName,
+					Size: int64(len(data)),
+					Data: data,
+				},
+			})
+
+			return pkg.Write(objPath)
+		})
 	}
 
 	return append(flags, newPaths...), nil

--- a/main.go
+++ b/main.go
@@ -32,7 +32,6 @@ import (
 	"unicode"
 
 	"github.com/Binject/debug/goobj2"
-
 	"golang.org/x/mod/module"
 	"golang.org/x/mod/semver"
 	"golang.org/x/tools/go/ast/astutil"
@@ -684,6 +683,8 @@ func transformCompile(args []string) ([]string, error) {
 				return err
 			}
 
+			// Adding an extra archive header is safe,
+			// and shouldn't break other tools like the linker since our header name is unique
 			pkg.ArchiveMembers = append(pkg.ArchiveMembers, goobj2.ArchiveMember{
 				ArchiveHeader: goobj2.ArchiveHeader{
 					Name: garbleMapHeaderName,


### PR DESCRIPTION
We now store how we obfuscated unexported names in the object file
itself, not a separate file. This means that the data can survive in the
build cache, whereas the separate file was being lost. Luckily, we can
just add an extra header to the archive, and other programs like the Go
linker will just ignore it.