### PR TITLE
WIP: file transformation logic update

### DIFF
--- a/line_obfuscator.go
+++ b/line_obfuscator.go
@@ -140,10 +140,15 @@ func processSpecialComments(commentGroups []*ast.CommentGroup) (extraComments, l
 	return extraComments, localnameBlacklist
 }
 
-func transformLineInfo(file *ast.File) ([]string, []string, *ast.File) {
+func transformLineInfo(file *ast.File, cgoFile bool) ([]string, []string, *ast.File) {
+	prefix := ""
+	if cgoFile {
+		prefix = "_cgo_"
+	}
+
 	// Save build tags and add file name leak protection
 	extraComments, localNameBlacklist := processSpecialComments(file.Comments)
-	extraComments = append(extraComments, "", "//line :1")
+	extraComments = append(extraComments, "", "//line "+prefix+":1")
 	file.Comments = nil
 
 	newLines := mathrand.Perm(len(file.Decls))
@@ -161,7 +166,7 @@ func transformLineInfo(file *ast.File) ([]string, []string, *ast.File) {
 			return true
 		}
 
-		comment := &ast.Comment{Text: fmt.Sprintf("//line %c.go:%d", nameCharset[mathrand.Intn(len(nameCharset))], PosMin+newLines[funcCounter])}
+		comment := &ast.Comment{Text: fmt.Sprintf("//line %s%c.go:%d", prefix, nameCharset[mathrand.Intn(len(nameCharset))], PosMin+newLines[funcCounter])}
 		funcDecl.Doc = prependComment(funcDecl.Doc, comment)
 		funcCounter++
 		return true

--- a/main.go
+++ b/main.go
@@ -581,7 +581,9 @@ func transformCompile(args []string) ([]string, error) {
 	filesExtraComments := make([][]string, len(files))
 
 	for i, file := range files {
-		extraComments, localNameBlacklist, file := transformLineInfo(file)
+		name := filepath.Base(filepath.Clean(paths[i]))
+		cgoFile := strings.HasPrefix(name, "_cgo_")
+		extraComments, localNameBlacklist, file := transformLineInfo(file, cgoFile)
 		for _, name := range localNameBlacklist {
 			localFunc := pkg.Scope().Lookup(name)
 			if localFunc == nil {

--- a/main.go
+++ b/main.go
@@ -581,7 +581,6 @@ func transformCompile(args []string) ([]string, error) {
 	filesExtraComments := make([][]string, len(files))
 
 	for i, file := range files {
-		println(paths[i])
 		extraComments, localNameBlacklist, file := transformLineInfo(file)
 		for _, name := range localNameBlacklist {
 			localFunc := pkg.Scope().Lookup(name)
@@ -601,12 +600,11 @@ func transformCompile(args []string) ([]string, error) {
 	// TODO: randomize the order and names of the files
 	newPaths := make([]string, 0, len(files))
 	for i, file := range files {
-		origName := filepath.Base(filepath.Clean(paths[i]))
-		name := origName
+		name := filepath.Base(filepath.Clean(paths[i]))
 		switch {
 		case pkgPath == "runtime":
 			// strip unneeded runtime code
-			stripRuntime(origName, file)
+			stripRuntime(name, file)
 		case pkgPath == "runtime/internal/sys":
 			// The first declaration in zversion.go contains the Go
 			// version as follows. Replace it here, since the
@@ -615,7 +613,7 @@ func transformCompile(args []string) ([]string, error) {
 			//     const TheVersion = `devel ...`
 			//
 			// Don't touch the source in any other way.
-			if origName != "zversion.go" {
+			if name != "zversion.go" {
 				break
 			}
 			spec := file.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec)

--- a/main.go
+++ b/main.go
@@ -147,6 +147,8 @@ func saveListedPackages(w io.Writer, flags, patterns []string) error {
 	}
 	dec := json.NewDecoder(stdout)
 	listedPackages = make(map[string]*listedPackage)
+
+	// TODO: Add ImportMap support
 	for dec.More() {
 		var pkg listedPackage
 		if err := dec.Decode(&pkg); err != nil {
@@ -703,7 +705,7 @@ func transformCompile(args []string) ([]string, error) {
 	return append(flags, newPaths...), nil
 }
 
-const privateBlacklist = "runtime,internal/cpu,internal/bytealg"
+const privateBlacklist = "runtime,internal/cpu,internal/bytealg,sync"
 
 // isPrivate checks if GOPRIVATE matches path.
 //


### PR DESCRIPTION
Complex pullrequest fixing global bugs.

- Fix https://github.com/burrowers/garble/issues/134
This bug occurred when files that do not pass through `transformGo` referred to the packages being processed. For example: runtime referred to the package time. **Fixed by forced processing of all files being compiled**
- ~Fix(in-progress) https://github.com/burrowers/garble/issues/125
This bug was triggered by directives referring to named functions (see `nameSpecialDirectives`). **Partially fixed by blocking renaming of local functions. Remained problem with unpredictable `[importpath.name]` in `//go:linkname` directive.**~
- ~Fix probable collision of short names~
- ~Length of short names is reduced (underscore removed).~

Fixes: https://github.com/burrowers/garble/issues/134
Fixes(in-progress): https://github.com/burrowers/garble/issues/125

Blocked by https://github.com/burrowers/garble/issues/146