### PR TITLE
Fixed comments cleaning

### DIFF
--- a/line_obfuscator.go
+++ b/line_obfuscator.go
@@ -49,12 +49,16 @@ func clearNodeComments(node ast.Node) {
 	switch n := node.(type) {
 	case *ast.Field:
 		n.Doc = clearCommentGroup(n.Doc)
+		n.Comment = nil
 	case *ast.ImportSpec:
 		n.Doc = clearCommentGroup(n.Doc)
+		n.Comment = nil
 	case *ast.ValueSpec:
 		n.Doc = clearCommentGroup(n.Doc)
+		n.Comment = nil
 	case *ast.TypeSpec:
 		n.Doc = clearCommentGroup(n.Doc)
+		n.Comment = nil
 	case *ast.GenDecl:
 		n.Doc = clearCommentGroup(n.Doc)
 	case *ast.FuncDecl:

--- a/testdata/scripts/debugdir.txt
+++ b/testdata/scripts/debugdir.txt
@@ -4,13 +4,21 @@ garble -debugdir ./test1 build
 exists 'test1/test/main/imported/imported.go' 'test1/main/main.go'
 ! grep ImportedFunc $WORK/test1/test/main/imported/imported.go
 ! grep ImportedFunc $WORK/test1/main/main.go
+! grep 'some comment' $WORK/test1/main/main.go
 
 -- go.mod --
 module test/main
 -- main.go --
 package main
 
-import "test/main/imported"
+import "test/main/imported" // some comment
+
+type someType int // some comment
+var someVar = 0
+
+type someStruct struct {
+    someField int // some comment
+}
 
 func main() {
 	imported.ImportedFunc()


### PR DESCRIPTION
Added cleanup of the Comment field. In some cases, the appearance of a comment in a random place may break the compilation (e.g. cgo and runtime package).

This is safe because the `Comment` field cannot contain any directives.


Part of https://github.com/burrowers/garble/pull/149