### PR TITLE
testdata: make syntax.txt pass when offline

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/Binject/debug v0.0.0-20200928131656-23d735563ce7
 	github.com/google/go-cmp v0.5.2
-	github.com/rogpeppe/go-internal v1.6.2-0.20200830194709-1115b6af0369
+	github.com/rogpeppe/go-internal v1.6.3-0.20201011174404-9f985d550aa7
 	golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449
 	golang.org/x/tools v0.0.0-20200928112810-42b62fc93869
 )

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/rogpeppe/go-internal v1.6.2-0.20200830194709-1115b6af0369 h1:wdCVGtPadWC/ZuuLC7Hv58VQ5UF7V98ewE71n5mJfrM=
-github.com/rogpeppe/go-internal v1.6.2-0.20200830194709-1115b6af0369/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rogpeppe/go-internal v1.6.3-0.20201011174404-9f985d550aa7 h1:gsBBcK+87059lM2pDrOQWXGoVx9qYgoBasBMJ74eCYI=
+github.com/rogpeppe/go-internal v1.6.3-0.20201011174404-9f985d550aa7/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/main.go
+++ b/main.go
@@ -467,7 +467,7 @@ func mainErr(args []string) error {
 				}
 				return err
 			}
-			line := string(bytes.TrimSpace(out))
+			line := string(bytes.TrimSpace(out)) // no trailing newline
 			f := strings.Fields(line)
 			if len(f) < 3 || f[0] != tool || f[1] != "version" || f[2] == "devel" && !strings.HasPrefix(f[len(f)-1], "buildID=") {
 				return fmt.Errorf("%s -V=full: unexpected output:\n\t%s", args[0], line)
@@ -482,7 +482,6 @@ func mainErr(args []string) error {
 				toolID = []byte(line)
 			}
 
-			out = bytes.TrimSpace(out) // no trailing newline
 			contentID, err := ownContentID(toolID)
 			if err != nil {
 				return fmt.Errorf("cannot obtain garble's own version: %v", err)

--- a/testdata/scripts/debugdir.txt
+++ b/testdata/scripts/debugdir.txt
@@ -17,7 +17,7 @@ type someType int // some comment
 var someVar = 0
 
 type someStruct struct {
-    someField int // some comment
+	someField int // some comment
 }
 
 func main() {

--- a/testdata/scripts/syntax.txt
+++ b/testdata/scripts/syntax.txt
@@ -1,14 +1,15 @@
-env GOPRIVATE='test/main,rsc.io/*'
+env GOPRIVATE='test/main,private.source/*'
 
 garble build -tags directives
 exec ./main$exe
 cmp stderr main.stderr
 
-! binsubstr main$exe 'localName' 'globalConst' 'globalVar' 'globalType' 'valuable information' 'rsc.io' 'remoteIntReturn' 'intReturn'
+! binsubstr main$exe 'localName' 'globalConst' 'globalVar' 'globalType' 'valuable information' 'private.source' 'remoteIntReturn' 'intReturn'
 binsubstr main$exe 'magicFunc'
 
 [short] stop # no need to verify this with -short
 
+# Check that the program works as expected without garble.
 go build -tags directives
 exec ./main$exe
 cmp stderr main.stderr
@@ -16,9 +17,20 @@ cmp stderr main.stderr
 binsubstr main$exe 'globalVar' # 'globalType' only matches on go < 1.15
 ! binsubstr main$exe 'localName' 'globalConst' 'remoteIntReturn' 'intReturn'
 
+-- extra/go.mod --
+module "private.source/extra"
+-- extra/extra.go --
+package extra
 
+func Func() string {
+	return "This is a separate module to obfuscate."
+}
 -- go.mod --
 module test/main
+
+// We include an extra module to obfuscate, included in the same original source
+// code via a replace directive.
+replace private.source/extra => ./extra
 -- main.go --
 package main
 
@@ -26,7 +38,7 @@ import (
 	"encoding/json"
 	"go/ast"
 
-	"rsc.io/quote"
+	"private.source/extra"
 	"test/main/sub"
 )
 
@@ -72,7 +84,7 @@ func main() {
 	enc, _ := json.Marshal(EncodingT{Foo: 3})
 	println(string(enc))
 	scopesTest()
-	println(quote.Go())
+	println(extra.Func())
 	sub.Test()
 	sub.TestDirectives()
 }
@@ -115,11 +127,11 @@ var someGlobalVar1 = "1"
 var someGlobalVar2 = "2"
 
 func Test() {
-    var A, B, C, D, E string
-    noop(A, B, C, D, E)
-    if someGlobalVar0 != "0" || someGlobalVar1 != "1" || someGlobalVar2 != "2"{
-        panic("name collision detected")
-    }
+	var A, B, C, D, E string
+	noop(A, B, C, D, E)
+	if someGlobalVar0 != "0" || someGlobalVar1 != "1" || someGlobalVar2 != "2"{
+		panic("name collision detected")
+	}
 }
 
 func noop(...interface{}) {}
@@ -130,8 +142,8 @@ func noop(...interface{}) {}
 package sub
 
 import (
-    _ "unsafe"
-    _ "test/main/sub/a"
+	_ "unsafe"
+	_ "test/main/sub/a"
 )
 
 //go:linkname remoteIntReturn a.magicFunc
@@ -140,9 +152,9 @@ func remoteIntReturn() int
 
 //go:noinline
 func TestDirectives() {
-    if remoteIntReturn() != 42 {
-        panic("invalid result")
-    }
+	if remoteIntReturn() != 42 {
+		panic("invalid result")
+	}
 }
 -- sub/a/directives.go --
 // +build directives
@@ -155,11 +167,11 @@ import _ "unsafe"
 
 //go:noinline
 func intReturn() int {
-    return 42
+	return 42
 }
 -- main.stderr --
 nil case
 {"Foo":3}
 1 1 1
 1 4 5 1 input
-Don't communicate by sharing memory, share memory by communicating.
+This is a separate module to obfuscate.


### PR DESCRIPTION
The test intended to use an extra module to be obfuscated, rsc.io/quote,
which we were bundling in the local proxy as well. Unfortunately, the
use of GOPRIVATE also meant that we did not actually fetch the module
from the proxy, and we would instead do a full roundtrip to the internet
to "git clone" the actual upstream repository.

To prevent that roundtrip, instead use a locally replaced module. This
fits the syntax.txt test too, since it's one more edge case that we want
to make sure works well with garble. Since rsc.io/quote is used in
another test, simply make up our own tiny module.

Reduces a 'go test -run Syntax/syntax' run with warm cache from ~5s to
~0.5s, thanks to removing the multiple roundtrips. A warm 'go test' run
still sits at ~6s, since we still need that much CPU time in total.

While at it, fix a staticcheck warning and fix inconsistent indentation
in a couple of tests.