### PR TITLE
CI: comment out test-gotip for now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,23 +25,24 @@ jobs:
         go version
         go test ./...
 
-  test-gotip:
-    runs-on: ubuntu-latest
-    continue-on-error: true # master breaks sometimes
-    steps:
-    - name: Install Go
-      run: |
-        git clone --depth=1 https://go.googlesource.com/go $HOME/gotip
-        cd $HOME/gotip/src
-        ./make.bash
-        echo "::set-env name=GOROOT::$HOME/gotip"
-        echo "::add-path::$HOME/gotip/bin"
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Test
-      run: |
-        go version
-        go test ./...
+  # TODO: re-enable once we get Go master/tip working again
+  #test-gotip:
+  #  runs-on: ubuntu-latest
+  #  continue-on-error: true # master breaks sometimes
+  #  steps:
+  #  - name: Install Go
+  #    run: |
+  #      git clone --depth=1 https://go.googlesource.com/go $HOME/gotip
+  #      cd $HOME/gotip/src
+  #      ./make.bash
+  #      echo "::set-env name=GOROOT::$HOME/gotip"
+  #      echo "::add-path::$HOME/gotip/bin"
+  #  - name: Checkout code
+  #    uses: actions/checkout@v2
+  #  - name: Test
+  #    run: |
+  #      go version
+  #      go test ./...
 
   code-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since it's been failing for weeks, it's practically useless for now.
Even with continue-on-error, the failures still look scary at first
glance.

We can re-enable this job once we fix master.