### PR TITLE
Allow struct fields to be garbled, fixes #48

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ packages to garble, set `GOPRIVATE`, documented at `go help module-private`.
 Most of these can improve with time and effort. The purpose of this section is
 to document the current shortcomings of this tool.
 
-* Exported methods and fields are never garbled at the moment, since they could
+* Exported methods are never garbled at the moment, since they could
   be required by interfaces and reflection. This area is a work in progress.
 
 * Functions implemented outside Go, such as assembly, aren't garbled since we

--- a/main.go
+++ b/main.go
@@ -930,10 +930,7 @@ func buildBlacklist(files []*ast.File, info *types.Info, pkg *types.Package) map
 	blacklist := make(map[types.Object]struct{})
 
 	reflectBlacklist := func(node ast.Node) bool {
-		expr, ok := node.(ast.Expr)
-		if !ok {
-			return true
-		}
+		expr, _ := node.(ast.Expr) // info.TypeOf(nil) will just return nil
 		named := namedType(info.TypeOf(expr))
 		if named == nil {
 			return true
@@ -1063,7 +1060,7 @@ func transformGo(file *ast.File, info *types.Info, blacklist map[types.Object]st
 		// log.Printf("%#v %T", node, obj)
 		switch x := obj.(type) {
 		case *types.Var:
-			if obj.Parent() != nil && obj.Parent() != pkg.Scope() {
+			if parent := obj.Parent(); parent != nil && parent != pkg.Scope() {
 				// identifiers of non-global variables never show up in the binary
 				return true
 			}

--- a/main.go
+++ b/main.go
@@ -930,7 +930,10 @@ func buildBlacklist(files []*ast.File, info *types.Info, pkg *types.Package) map
 	blacklist := make(map[types.Object]struct{})
 
 	reflectBlacklist := func(node ast.Node) bool {
-		expr, _ := node.(ast.Expr)
+		expr, ok := node.(ast.Expr)
+		if !ok {
+			return true
+		}
 		named := namedType(info.TypeOf(expr))
 		if named == nil {
 			return true
@@ -1060,17 +1063,10 @@ func transformGo(file *ast.File, info *types.Info, blacklist map[types.Object]st
 		// log.Printf("%#v %T", node, obj)
 		switch x := obj.(type) {
 		case *types.Var:
-			if x.IsField() && x.Exported() {
-				// might be used for reflection, e.g.
-				// encoding/json without struct tags
-				return true
-			}
-
-			if obj.Parent() != pkg.Scope() {
+			if obj.Parent() != nil && obj.Parent() != pkg.Scope() {
 				// identifiers of non-global variables never show up in the binary
 				return true
 			}
-
 		case *types.TypeName:
 			if obj.Parent() != pkg.Scope() {
 				// identifiers of non-global types never show up in the binary

--- a/testdata/scripts/imports.txt
+++ b/testdata/scripts/imports.txt
@@ -5,7 +5,7 @@ garble build -tags buildtag
 exec ./main
 cmp stdout main.stdout
 
-! binsubstr main$exe 'ImportedVar' 'ImportedConst' 'ImportedFunc' 'ImportedType' 'main.go' 'test/main' 'imported.'
+! binsubstr main$exe 'ImportedVar' 'ImportedConst' 'ImportedFunc' 'ImportedType' 'main.go' 'test/main' 'imported.' 'NormalStruct' 'NormalExportedField' 'normalUnexportedField'
 
 [short] stop # checking that the build is reproducible is slow
 
@@ -50,6 +50,7 @@ func main() {
 	fmt.Println(imported.ImportedConst)
 	fmt.Println(imported.ImportedFunc('x'))
 	fmt.Println(imported.ImportedType(3))
+	fmt.Println(imported.NormalStruct{})
 
 	printfWithoutPackage("%T\n", imported.ReflectTypeOf(2))
 	printfWithoutPackage("%T\n", imported.ReflectTypeOfIndirect(4))
@@ -117,6 +118,11 @@ var ReflectValueOfVar = ReflectValueOf{ExportedField: "abc"}
 
 var _ = reflect.TypeOf(ReflectValueOfVar)
 
+type NormalStruct struct {
+	NormalExportedField   int
+	normalUnexportedField int
+}
+
 // ImportedType comes after the calls to reflect, to ensure no false positives.
 type ImportedType int
 
@@ -126,6 +132,7 @@ imported var value
 imported const value
 x
 3
+{0 0}
 ReflectTypeOf
 ReflectTypeOfIndirect
 ReflectValueOf{ExportedField:"abc", unexportedField:""}

--- a/testdata/scripts/syntax.txt
+++ b/testdata/scripts/syntax.txt
@@ -37,6 +37,7 @@ package main
 import (
 	"encoding/json"
 	"go/ast"
+	"reflect"
 
 	"private.source/extra"
 	"test/main/sub"
@@ -81,6 +82,7 @@ func main() {
 		println("nil case")
 	}
 
+	var _ = reflect.TypeOf(EncodingT{})
 	enc, _ := json.Marshal(EncodingT{Foo: 3})
 	println(string(enc))
 	scopesTest()


### PR DESCRIPTION
This additionally fixes a bug that prevented unexported struct fields from being garbled. The check at https://github.com/burrowers/garble/blob/master/main.go#L1069 returns true for all struct fields, as their object's `Parent()` returns `nil`. As you can see in the amended `syntax` test script, garble currently does not detect reflect usage of stdlib functions and methods, that should be opened in a separate issue I think.