### PR TITLE
properly remove all filenames when -tiny is passed

### DIFF
--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -291,6 +291,10 @@ func stripPCLinesAndNames(am *goobj2.ArchiveMember) {
 	lists := [][]*goobj2.Sym{am.SymDefs, am.NonPkgSymDefs, am.NonPkgSymRefs}
 	for _, list := range lists {
 		for _, s := range list {
+			if strings.HasPrefix(s.Name, "gofile..") {
+				s.Name = "gofile.."
+			}
+
 			if s.Func == nil {
 				continue
 			}
@@ -493,6 +497,11 @@ func garbleSymbolName(symName string, privImports privateImports, garbledImports
 	if skipSym {
 		// log.Printf("\t\t? Skipped symbol: %s", symName)
 		return symName
+	}
+
+	// remove filename symbols when -tiny is passed
+	if envGarbleTiny && prefix == "gofile.." {
+		return prefix
 	}
 
 	var namedataSym bool

--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -291,6 +291,11 @@ func stripPCLinesAndNames(am *goobj2.ArchiveMember) {
 	lists := [][]*goobj2.Sym{am.SymDefs, am.NonPkgSymDefs, am.NonPkgSymRefs}
 	for _, list := range lists {
 		for _, s := range list {
+			// remove filename symbols when -tiny is passed as they
+			// are only used for printing panics, and -tiny removes
+			// panic printing; we need to set the symbol names to
+			// 'gofile..', otherwise the linker will expect to see
+			// filename symbols and panic
 			if strings.HasPrefix(s.Name, "gofile..") {
 				s.Name = "gofile.."
 			}
@@ -500,6 +505,8 @@ func garbleSymbolName(symName string, privImports privateImports, garbledImports
 	}
 
 	// remove filename symbols when -tiny is passed
+	// as they are only used for printing panics,
+	// and -tiny removes panic printing
 	if envGarbleTiny && prefix == "gofile.." {
 		return prefix
 	}

--- a/testdata/scripts/tiny.txt
+++ b/testdata/scripts/tiny.txt
@@ -2,11 +2,11 @@ env GOPRIVATE=test/main
 
 # Tiny mode
 garble -tiny build
+! binsubstr main$exe 'main.go' 'fmt/print.go'
 env GODEBUG='allocfreetrace=1,gcpacertrace=1,gctrace=1,scavenge=1,scavtrace=1,scheddetail=1,schedtrace=10'
 ! exec ./main$exe
 cmp stdout main.stdout
 stderr '\? 0'
-! binsubstr main$exe 'main.go' 'fmt/print.go'
 
 [short] stop # no need to verify this with -short
 

--- a/testdata/scripts/tiny.txt
+++ b/testdata/scripts/tiny.txt
@@ -6,6 +6,7 @@ env GODEBUG='allocfreetrace=1,gcpacertrace=1,gctrace=1,scavenge=1,scavtrace=1,sc
 ! exec ./main$exe
 cmp stdout main.stdout
 stderr '\? 0'
+! binsubstr main$exe 'main.go' 'fmt/print.go'
 
 [short] stop # no need to verify this with -short
 


### PR DESCRIPTION
Previously, only line number information was removed when `-tiny` was passed, but not filenames. Now all filenames are removed when `-tiny` is passed. When `-tiny` is not passed, the behavior is unaffected. Any import paths in GOPRIVATE that are in a filename will be hashed, but the filename itself will not be removed.