### PR TITLE
Fix bug where structs would get garbled in some packages but not in others

### DIFF
--- a/main.go
+++ b/main.go
@@ -995,7 +995,7 @@ func collectNames(files []*ast.File) map[string]struct{} {
 }
 
 // transformGo garbles the provided Go syntax node.
-func transformGo(file *ast.File, info *types.Info, blacklist map[types.Object]struct{}, pkgScope *types.Scope, privateNameMap map[string]string, pkgPath string, existingNames map[string]struct{}, packageCounter *int) *ast.File {
+func transformGo(file *ast.File, info *types.Info, blacklist map[types.Object]struct{}, filePkgScope *types.Scope, privateNameMap map[string]string, pkgPath string, existingNames map[string]struct{}, packageCounter *int) *ast.File {
 	// Shuffle top level declarations
 	mathrand.Shuffle(len(file.Decls), func(i, j int) {
 		decl1 := file.Decls[i]
@@ -1067,7 +1067,7 @@ func transformGo(file *ast.File, info *types.Info, blacklist map[types.Object]st
 
 			// if the struct of this field was not garbled, do not garble
 			// any of that struct's fields
-			if (parentScope != pkgScope) && (x.IsField() && !x.Embedded()) {
+			if (parentScope != filePkgScope) && (x.IsField() && !x.Embedded()) {
 				parent, ok := cursor.Parent().(*ast.SelectorExpr)
 				if !ok {
 					break
@@ -1099,7 +1099,7 @@ func transformGo(file *ast.File, info *types.Info, blacklist map[types.Object]st
 
 			// if the type was not garbled in the package were it was defined,
 			// do not garble it here
-			if parentScope != pkgScope {
+			if parentScope != filePkgScope {
 				named := namedType(x.Type())
 				if named == nil {
 					break

--- a/testdata/scripts/imports.txt
+++ b/testdata/scripts/imports.txt
@@ -52,7 +52,8 @@ func main() {
 	fmt.Println(imported.ImportedFunc('x'))
 	fmt.Println(imported.ImportedType(3))
 	fmt.Println(imported.ReflectInDefinedVar.ExportedField2)
-	fmt.Println(imported.NormalStruct{})
+	fmt.Println(imported.ReflectInDefined{ExportedField2: 5})
+	fmt.Println(imported.NormalStruct{SharedName: 3})
 
 	printfWithoutPackage("%T\n", imported.ReflectTypeOf(2))
 	printfWithoutPackage("%T\n", imported.ReflectTypeOfIndirect(4))
@@ -130,8 +131,10 @@ var ReflectInDefinedVar = ReflectInDefined{ExportedField2: 9000}
 
 var _ = reflect.TypeOf(ReflectInDefinedVar)
 
+const SharedName = 2
+
 type NormalStruct struct {
-	NormalExportedField   int
+	SharedName   int
 	normalUnexportedField int
 }
 
@@ -145,7 +148,8 @@ imported const value
 x
 3
 9000
-{0 0}
+{5 0}
+{3 0}
 ReflectTypeOf
 ReflectTypeOfIndirect
 ReflectValueOf{ExportedField:"abc", unexportedField:""}

--- a/testdata/scripts/imports.txt
+++ b/testdata/scripts/imports.txt
@@ -6,6 +6,7 @@ exec ./main
 cmp stdout main.stdout
 
 ! binsubstr main$exe 'ImportedVar' 'ImportedConst' 'ImportedFunc' 'ImportedType' 'main.go' 'test/main' 'imported.' 'NormalStruct' 'NormalExportedField' 'normalUnexportedField'
+binsubstr main$exe 'ReflectInDefined' 'ExportedField2' 'unexportedField2'
 
 [short] stop # checking that the build is reproducible is slow
 
@@ -50,6 +51,7 @@ func main() {
 	fmt.Println(imported.ImportedConst)
 	fmt.Println(imported.ImportedFunc('x'))
 	fmt.Println(imported.ImportedType(3))
+	fmt.Println(imported.ReflectInDefinedVar.ExportedField2)
 	fmt.Println(imported.NormalStruct{})
 
 	printfWithoutPackage("%T\n", imported.ReflectTypeOf(2))
@@ -118,6 +120,16 @@ var ReflectValueOfVar = ReflectValueOf{ExportedField: "abc"}
 
 var _ = reflect.TypeOf(ReflectValueOfVar)
 
+type ReflectInDefined struct {
+	ExportedField2   int
+
+	unexportedField2 int
+}
+
+var ReflectInDefinedVar = ReflectInDefined{ExportedField2: 9000}
+
+var _ = reflect.TypeOf(ReflectInDefinedVar)
+
 type NormalStruct struct {
 	NormalExportedField   int
 	normalUnexportedField int
@@ -132,6 +144,7 @@ imported var value
 imported const value
 x
 3
+9000
 {0 0}
 ReflectTypeOf
 ReflectTypeOfIndirect


### PR DESCRIPTION
The bug fixed by this PR is a bit tricky: if package P defines struct S, and reflection is used on struct S in package P, garble won't rename struct S or any of it's fields in package P. But, if package P2 imports package P and uses struct S, garble *will* rename struct S and it's fields, as reflection was not used on struct S in package P2. The fix is to only rename structs and their fields if they were already renamed in the package they were defined in.