### PR TITLE
Keep init functions in original order

### DIFF
--- a/main.go
+++ b/main.go
@@ -1008,11 +1008,19 @@ func transformGo(file *ast.File, info *types.Info, blacklist map[types.Object]st
 		decl2 := file.Decls[j]
 
 		// Import declarations must remain at the top of the file.
-		gd1, ok1 := decl1.(*ast.GenDecl)
-		gd2, ok2 := decl2.(*ast.GenDecl)
-		if (ok1 && gd1.Tok == token.IMPORT) || (ok2 && gd2.Tok == token.IMPORT) {
+		gd1, iok1 := decl1.(*ast.GenDecl)
+		gd2, iok2 := decl2.(*ast.GenDecl)
+		if (iok1 && gd1.Tok == token.IMPORT) || (iok2 && gd2.Tok == token.IMPORT) {
 			return
 		}
+
+		// init function declarations must remain in order.
+		fd1, fok1 := decl1.(*ast.FuncDecl)
+		fd2, fok2 := decl2.(*ast.FuncDecl)
+		if (fok1 && fd1.Name.Name == "init") || (fok2 && fd2.Name.Name == "init") {
+			return
+		}
+
 		file.Decls[i], file.Decls[j] = decl2, decl1
 	})
 

--- a/testdata/scripts/init.txt
+++ b/testdata/scripts/init.txt
@@ -1,0 +1,73 @@
+# Test that garble keeps init functions in the order they were declared in
+
+garble build
+exec ./main
+cmp stdout main.stdout
+
+[short] stop # no need to verify this with -short
+
+go build
+exec ./main
+cmp stdout main.stdout
+
+-- go.mod --
+module test/main
+-- main.go --
+package main
+
+import (
+    "fmt"
+    "strings"
+)
+
+var exploded []string
+
+func init() {
+    exploded = append(exploded, "B")
+}
+
+func init() {
+    exploded = append(exploded, "i")
+}
+
+func init() {
+    exploded = append(exploded, "g")
+}
+
+func init() {
+    exploded = append(exploded, " ")
+}
+
+func init() {
+    exploded = append(exploded, "C")
+}
+
+func init() {
+    exploded = append(exploded, "h")
+}
+
+func init() {
+    exploded = append(exploded, "u")
+}
+
+func init() {
+    exploded = append(exploded, "n")
+}
+
+func init() {
+    exploded = append(exploded, "g")
+}
+
+func init() {
+    exploded = append(exploded, "u")
+}
+
+func init() {
+    exploded = append(exploded, "s")
+}
+
+func main() {
+	fmt.Println(strings.Join(exploded, ""))
+}
+-- main.stdout --
+Big Chungus


### PR DESCRIPTION
Previously, `init` functions order were randomized along with all other declarations, which could lead to runtime errors.