### PR TITLE
testdata: avoid unnecessary deps in init.txt

### DIFF
--- a/testdata/scripts/init.txt
+++ b/testdata/scripts/init.txt
@@ -1,73 +1,68 @@
-# Test that garble keeps init functions in the order they were declared in
+# Test that garble keeps init functions in the order they were declared in.
 
 garble build
 exec ./main
-cmp stdout main.stdout
+cmp stderr main.stderr
 
 [short] stop # no need to verify this with -short
 
 go build
 exec ./main
-cmp stdout main.stdout
+cmp stderr main.stderr
 
 -- go.mod --
 module test/main
 -- main.go --
 package main
 
-import (
-    "fmt"
-    "strings"
-)
-
-var exploded []string
+var exploded []byte
 
 func init() {
-    exploded = append(exploded, "B")
+	exploded = append(exploded, 'B')
 }
 
 func init() {
-    exploded = append(exploded, "i")
+	exploded = append(exploded, 'i')
 }
 
 func init() {
-    exploded = append(exploded, "g")
+	exploded = append(exploded, 'g')
 }
 
 func init() {
-    exploded = append(exploded, " ")
+	exploded = append(exploded, ' ')
 }
 
 func init() {
-    exploded = append(exploded, "C")
+	exploded = append(exploded, 'C')
 }
 
 func init() {
-    exploded = append(exploded, "h")
+	exploded = append(exploded, 'h')
 }
 
 func init() {
-    exploded = append(exploded, "u")
+	exploded = append(exploded, 'u')
 }
 
 func init() {
-    exploded = append(exploded, "n")
+	exploded = append(exploded, 'n')
 }
 
 func init() {
-    exploded = append(exploded, "g")
+	exploded = append(exploded, 'g')
 }
 
 func init() {
-    exploded = append(exploded, "u")
+	exploded = append(exploded, 'u')
 }
 
 func init() {
-    exploded = append(exploded, "s")
+	exploded = append(exploded, 's')
 }
 
 func main() {
-	fmt.Println(strings.Join(exploded, ""))
+	println(string(exploded))
 }
--- main.stdout --
+-- main.stderr --
 Big Chungus


### PR DESCRIPTION
We can use println instead of fmt.Println. Similarly, we can avoid
strings.Join by just appending bytes to a []byte.

This is less important now that we have build caching, but it still
helps to do less work overall and link smaller binaries.

Reduces 'go test -run Script/init' from 0.5s to 0.3s on my laptop.

Also, properly format the Go in that file, since the space indentation
wasn't noticed during code review. We might want to enforce gofmt in Go
files within txtar files if this keeps happening.