### PR TITLE
testdata: make tiny.txt simpler and faster

### DIFF
--- a/testdata/scripts/tiny.txt
+++ b/testdata/scripts/tiny.txt
@@ -5,8 +5,9 @@ garble -tiny build
 ! binsubstr main$exe 'main.go' 'fmt/print.go'
 env GODEBUG='allocfreetrace=1,gcpacertrace=1,gctrace=1,scavenge=1,scavtrace=1,scheddetail=1,schedtrace=10'
 ! exec ./main$exe
-cmp stdout main.stdout
-stderr '\? 0'
+stderr '^caller: \? 0$' # position info is removed
+stderr '^recovered: ya like jazz?'
+! stderr 'panic: oh noes' # panics are hidden
 
 [short] stop # no need to verify this with -short
 
@@ -14,32 +15,27 @@ stderr '\? 0'
 env GODEBUG=
 garble build
 ! exec ./main$exe
-cmp stdout main.stdout
-stderr '\w\.go [1-9]'
+stderr '^caller: \w\.go [1-9]'
+stderr '^recovered: ya like jazz?'
+stderr 'panic: oh noes'
 
 -- go.mod --
 module test/main
 -- main.go --
 package main
 
-import (
-	"fmt"
-	"runtime"
-)
+import "runtime"
 
 func main() {
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Println(r)
+			println("recovered:", r.(string))
 			panic("oh noes")
 		}
 	}()
 
 	_, file, line, _ := runtime.Caller(0)
-	println(file, line)
+	println("caller:", file, line)
 
 	panic("ya like jazz?")
 }
-
--- main.stdout --
-ya like jazz?


### PR DESCRIPTION
By avoiding the fmt import, we save some work: 'go test -run Script/tiny'
goes down from 0.8s to 0.5s even with a warm build cache.

Since the output changes between runs, we use stderr grep lines instead
of cmp. This way we can also check that the "oh noes" panic is entirely
hidden in the tiny mode.