### PR TITLE
Replaced asthelper.Ident with ast.NewIdent

### DIFF
--- a/internal/asthelper/asthelper.go
+++ b/internal/asthelper/asthelper.go
@@ -10,11 +10,6 @@ import (
 	"strconv"
 )
 
-// Ident an identifier
-func Ident(name string) *ast.Ident {
-	return &ast.Ident{Name: name}
-}
-
 // StringLit returns an ast.BasicLit of kind STRING
 func StringLit(value string) *ast.BasicLit {
 	return &ast.BasicLit{
@@ -50,7 +45,7 @@ func Float64Lit(value float64) *ast.BasicLit {
 // IndexExpr "name[index]"
 func IndexExpr(name string, index ast.Expr) *ast.IndexExpr {
 	return &ast.IndexExpr{
-		X:     Ident(name),
+		X:     ast.NewIdent(name),
 		Index: index,
 	}
 }
@@ -89,7 +84,7 @@ func ReturnStmt(results ...ast.Expr) *ast.ReturnStmt {
 // BoundsCheck "_ = name[pos]"
 func BoundsCheck(name string, pos int) *ast.AssignStmt {
 	return &ast.AssignStmt{
-		Lhs: []ast.Expr{Ident("_")},
+		Lhs: []ast.Expr{ast.NewIdent("_")},
 		Tok: token.ASSIGN,
 		Rhs: []ast.Expr{IndexExpr("data", IntLit(pos))},
 	}

--- a/internal/literals/literals.go
+++ b/internal/literals/literals.go
@@ -163,16 +163,16 @@ func obfuscateString(data string) *ast.CallExpr {
 	obfuscator := randObfuscator()
 	block := obfuscator.obfuscate([]byte(data))
 
-	block.List = append(block.List, ah.ReturnStmt(ah.CallExpr(ah.Ident("string"), ah.Ident("data"))))
+	block.List = append(block.List, ah.ReturnStmt(ah.CallExpr(ast.NewIdent("string"), ast.NewIdent("data"))))
 
-	return ah.LambdaCall(ah.Ident("string"), block)
+	return ah.LambdaCall(ast.NewIdent("string"), block)
 }
 
 func obfuscateByteSlice(data []byte) *ast.CallExpr {
 	obfuscator := randObfuscator()
 	block := obfuscator.obfuscate(data)
-	block.List = append(block.List, ah.ReturnStmt(ah.Ident("data")))
-	return ah.LambdaCall(&ast.ArrayType{Elt: ah.Ident("byte")}, block)
+	block.List = append(block.List, ah.ReturnStmt(ast.NewIdent("data")))
+	return ah.LambdaCall(&ast.ArrayType{Elt: ast.NewIdent("byte")}, block)
 }
 
 func obfuscateByteArray(data []byte, length int64) *ast.CallExpr {
@@ -181,7 +181,7 @@ func obfuscateByteArray(data []byte, length int64) *ast.CallExpr {
 
 	arrayType := &ast.ArrayType{
 		Len: ah.IntLit(int(length)),
-		Elt: ah.Ident("byte"),
+		Elt: ast.NewIdent("byte"),
 	}
 
 	sliceToArray := []ast.Stmt{
@@ -189,24 +189,24 @@ func obfuscateByteArray(data []byte, length int64) *ast.CallExpr {
 			Decl: &ast.GenDecl{
 				Tok: token.VAR,
 				Specs: []ast.Spec{&ast.ValueSpec{
-					Names: []*ast.Ident{ah.Ident("newdata")},
+					Names: []*ast.Ident{ast.NewIdent("newdata")},
 					Type:  arrayType,
 				}},
 			},
 		},
 		&ast.RangeStmt{
-			Key: ah.Ident("i"),
+			Key: ast.NewIdent("i"),
 			Tok: token.DEFINE,
-			X:   ah.Ident("newdata"),
+			X:   ast.NewIdent("newdata"),
 			Body: &ast.BlockStmt{List: []ast.Stmt{
 				&ast.AssignStmt{
-					Lhs: []ast.Expr{ah.IndexExpr("newdata", ah.Ident("i"))},
+					Lhs: []ast.Expr{ah.IndexExpr("newdata", ast.NewIdent("i"))},
 					Tok: token.ASSIGN,
-					Rhs: []ast.Expr{ah.IndexExpr("data", ah.Ident("i"))},
+					Rhs: []ast.Expr{ah.IndexExpr("data", ast.NewIdent("i"))},
 				},
 			}},
 		},
-		ah.ReturnStmt(ah.Ident("newdata")),
+		ah.ReturnStmt(ast.NewIdent("newdata")),
 	}
 
 	block.List = append(block.List, sliceToArray...)

--- a/internal/literals/seed.go
+++ b/internal/literals/seed.go
@@ -27,7 +27,7 @@ func (seed) obfuscate(data []byte) *ast.BlockStmt {
 		seed += encB
 
 		if i == 0 {
-			callExpr = ah.CallExpr(ah.Ident("fnc"), ah.IntLit(int(encB)))
+			callExpr = ah.CallExpr(ast.NewIdent("fnc"), ah.IntLit(int(encB)))
 			continue
 		}
 
@@ -36,16 +36,16 @@ func (seed) obfuscate(data []byte) *ast.BlockStmt {
 
 	return ah.BlockStmt(
 		&ast.AssignStmt{
-			Lhs: []ast.Expr{ah.Ident("seed")},
+			Lhs: []ast.Expr{ast.NewIdent("seed")},
 			Tok: token.DEFINE,
-			Rhs: []ast.Expr{ah.CallExpr(ah.Ident("byte"), ah.IntLit(int(originalSeed)))},
+			Rhs: []ast.Expr{ah.CallExpr(ast.NewIdent("byte"), ah.IntLit(int(originalSeed)))},
 		},
 		&ast.DeclStmt{
 			Decl: &ast.GenDecl{
 				Tok: token.VAR,
 				Specs: []ast.Spec{&ast.ValueSpec{
-					Names: []*ast.Ident{ah.Ident("data")},
-					Type:  &ast.ArrayType{Elt: ah.Ident("byte")},
+					Names: []*ast.Ident{ast.NewIdent("data")},
+					Type:  &ast.ArrayType{Elt: ast.NewIdent("byte")},
 				}},
 			},
 		},
@@ -53,13 +53,13 @@ func (seed) obfuscate(data []byte) *ast.BlockStmt {
 			Decl: &ast.GenDecl{
 				Tok: token.TYPE,
 				Specs: []ast.Spec{&ast.TypeSpec{
-					Name: ah.Ident("decFunc"),
+					Name: ast.NewIdent("decFunc"),
 					Type: &ast.FuncType{
 						Params: &ast.FieldList{List: []*ast.Field{
-							{Type: ah.Ident("byte")},
+							{Type: ast.NewIdent("byte")},
 						}},
 						Results: &ast.FieldList{List: []*ast.Field{
-							{Type: ah.Ident("decFunc")},
+							{Type: ast.NewIdent("decFunc")},
 						}},
 					},
 				}},
@@ -69,43 +69,43 @@ func (seed) obfuscate(data []byte) *ast.BlockStmt {
 			Decl: &ast.GenDecl{
 				Tok: token.VAR,
 				Specs: []ast.Spec{&ast.ValueSpec{
-					Names: []*ast.Ident{ah.Ident("fnc")},
-					Type:  ah.Ident("decFunc"),
+					Names: []*ast.Ident{ast.NewIdent("fnc")},
+					Type:  ast.NewIdent("decFunc"),
 				}},
 			},
 		},
 		&ast.AssignStmt{
-			Lhs: []ast.Expr{ah.Ident("fnc")},
+			Lhs: []ast.Expr{ast.NewIdent("fnc")},
 			Tok: token.ASSIGN,
 			Rhs: []ast.Expr{
 				&ast.FuncLit{
 					Type: &ast.FuncType{
 						Params: &ast.FieldList{
 							List: []*ast.Field{{
-								Names: []*ast.Ident{ah.Ident("x")},
-								Type:  ah.Ident("byte"),
+								Names: []*ast.Ident{ast.NewIdent("x")},
+								Type:  ast.NewIdent("byte"),
 							}},
 						},
 						Results: &ast.FieldList{
 							List: []*ast.Field{{
-								Type: ah.Ident("decFunc"),
+								Type: ast.NewIdent("decFunc"),
 							}},
 						},
 					},
 					Body: ah.BlockStmt(
 						&ast.AssignStmt{
-							Lhs: []ast.Expr{ah.Ident("data")},
+							Lhs: []ast.Expr{ast.NewIdent("data")},
 							Tok: token.ASSIGN,
 							Rhs: []ast.Expr{
-								ah.CallExpr(ah.Ident("append"), ah.Ident("data"), operatorToReversedBinaryExpr(op, ah.Ident("x"), ah.Ident("seed"))),
+								ah.CallExpr(ast.NewIdent("append"), ast.NewIdent("data"), operatorToReversedBinaryExpr(op, ast.NewIdent("x"), ast.NewIdent("seed"))),
 							},
 						},
 						&ast.AssignStmt{
-							Lhs: []ast.Expr{ah.Ident("seed")},
+							Lhs: []ast.Expr{ast.NewIdent("seed")},
 							Tok: token.ADD_ASSIGN,
-							Rhs: []ast.Expr{ah.Ident("x")},
+							Rhs: []ast.Expr{ast.NewIdent("x")},
 						},
-						ah.ReturnStmt(ah.Ident("fnc")),
+						ah.ReturnStmt(ast.NewIdent("fnc")),
 					),
 				},
 			},

--- a/internal/literals/shuffle.go
+++ b/internal/literals/shuffle.go
@@ -37,7 +37,7 @@ func (shuffle) obfuscate(data []byte) *ast.BlockStmt {
 		shuffledFullData[shuffledIdxs[i]] = b
 	}
 
-	args := []ast.Expr{ah.Ident("data")}
+	args := []ast.Expr{ast.NewIdent("data")}
 	for i := range data {
 		args = append(args, operatorToReversedBinaryExpr(
 			operators[i],
@@ -48,7 +48,7 @@ func (shuffle) obfuscate(data []byte) *ast.BlockStmt {
 
 	return ah.BlockStmt(
 		&ast.AssignStmt{
-			Lhs: []ast.Expr{ah.Ident("fullData")},
+			Lhs: []ast.Expr{ast.NewIdent("fullData")},
 			Tok: token.DEFINE,
 			Rhs: []ast.Expr{ah.DataToByteSlice(shuffledFullData)},
 		},
@@ -56,15 +56,15 @@ func (shuffle) obfuscate(data []byte) *ast.BlockStmt {
 			Decl: &ast.GenDecl{
 				Tok: token.VAR,
 				Specs: []ast.Spec{&ast.ValueSpec{
-					Names: []*ast.Ident{ah.Ident("data")},
-					Type:  &ast.ArrayType{Elt: ah.Ident("byte")},
+					Names: []*ast.Ident{ast.NewIdent("data")},
+					Type:  &ast.ArrayType{Elt: ast.NewIdent("byte")},
 				}},
 			},
 		},
 		&ast.AssignStmt{
-			Lhs: []ast.Expr{ah.Ident("data")},
+			Lhs: []ast.Expr{ast.NewIdent("data")},
 			Tok: token.ASSIGN,
-			Rhs: []ast.Expr{ah.CallExpr(ah.Ident("append"), args...)},
+			Rhs: []ast.Expr{ah.CallExpr(ast.NewIdent("append"), args...)},
 		},
 	)
 }

--- a/internal/literals/simple.go
+++ b/internal/literals/simple.go
@@ -26,25 +26,25 @@ func (simple) obfuscate(data []byte) *ast.BlockStmt {
 
 	return ah.BlockStmt(
 		&ast.AssignStmt{
-			Lhs: []ast.Expr{ah.Ident("key")},
+			Lhs: []ast.Expr{ast.NewIdent("key")},
 			Tok: token.DEFINE,
 			Rhs: []ast.Expr{ah.DataToByteSlice(key)},
 		},
 		&ast.AssignStmt{
-			Lhs: []ast.Expr{ah.Ident("data")},
+			Lhs: []ast.Expr{ast.NewIdent("data")},
 			Tok: token.DEFINE,
 			Rhs: []ast.Expr{ah.DataToByteSlice(data)},
 		},
 		&ast.RangeStmt{
-			Key:   ah.Ident("i"),
-			Value: ah.Ident("b"),
+			Key:   ast.NewIdent("i"),
+			Value: ast.NewIdent("b"),
 			Tok:   token.DEFINE,
-			X:     ah.Ident("key"),
+			X:     ast.NewIdent("key"),
 			Body: &ast.BlockStmt{List: []ast.Stmt{
 				&ast.AssignStmt{
-					Lhs: []ast.Expr{ah.IndexExpr("data", ah.Ident("i"))},
+					Lhs: []ast.Expr{ah.IndexExpr("data", ast.NewIdent("i"))},
 					Tok: token.ASSIGN,
-					Rhs: []ast.Expr{operatorToReversedBinaryExpr(op, ah.IndexExpr("data", ah.Ident("i")), ah.Ident("b"))},
+					Rhs: []ast.Expr{operatorToReversedBinaryExpr(op, ah.IndexExpr("data", ast.NewIdent("i")), ast.NewIdent("b"))},
 				},
 			}},
 		},

--- a/internal/literals/split.go
+++ b/internal/literals/split.go
@@ -97,25 +97,25 @@ func (split) obfuscate(data []byte) *ast.BlockStmt {
 		List: []ast.Expr{ah.IntLit(decryptIndex)},
 		Body: shuffleStmts(
 			&ast.AssignStmt{
-				Lhs: []ast.Expr{ah.Ident("i")},
+				Lhs: []ast.Expr{ast.NewIdent("i")},
 				Tok: token.ASSIGN,
 				Rhs: []ast.Expr{ah.IntLit(exitIndex)},
 			},
 			&ast.RangeStmt{
-				Key: ah.Ident("y"),
+				Key: ast.NewIdent("y"),
 				Tok: token.DEFINE,
-				X:   ah.Ident("data"),
+				X:   ast.NewIdent("data"),
 				Body: ah.BlockStmt(&ast.AssignStmt{
-					Lhs: []ast.Expr{ah.IndexExpr("data", ah.Ident("y"))},
+					Lhs: []ast.Expr{ah.IndexExpr("data", ast.NewIdent("y"))},
 					Tok: token.ASSIGN,
 					Rhs: []ast.Expr{
 						operatorToReversedBinaryExpr(
 							op,
-							ah.IndexExpr("data", ah.Ident("y")),
-							ah.CallExpr(ah.Ident("byte"), &ast.BinaryExpr{
-								X:  ah.Ident("decryptKey"),
+							ah.IndexExpr("data", ast.NewIdent("y")),
+							ah.CallExpr(ast.NewIdent("byte"), &ast.BinaryExpr{
+								X:  ast.NewIdent("decryptKey"),
 								Op: token.XOR,
-								Y:  ah.Ident("y"),
+								Y:  ast.NewIdent("y"),
 							}),
 						),
 					},
@@ -129,8 +129,8 @@ func (split) obfuscate(data []byte) *ast.BlockStmt {
 		chunk := chunks[i]
 
 		appendCallExpr := &ast.CallExpr{
-			Fun:  ah.Ident("append"),
-			Args: []ast.Expr{ah.Ident("data")},
+			Fun:  ast.NewIdent("append"),
+			Args: []ast.Expr{ast.NewIdent("data")},
 		}
 
 		if len(chunk) != 1 {
@@ -144,12 +144,12 @@ func (split) obfuscate(data []byte) *ast.BlockStmt {
 			List: []ast.Expr{ah.IntLit(index)},
 			Body: shuffleStmts(
 				&ast.AssignStmt{
-					Lhs: []ast.Expr{ah.Ident("i")},
+					Lhs: []ast.Expr{ast.NewIdent("i")},
 					Tok: token.ASSIGN,
 					Rhs: []ast.Expr{ah.IntLit(nextIndex)},
 				},
 				&ast.AssignStmt{
-					Lhs: []ast.Expr{ah.Ident("data")},
+					Lhs: []ast.Expr{ast.NewIdent("data")},
 					Tok: token.ASSIGN,
 					Rhs: []ast.Expr{appendCallExpr},
 				},
@@ -162,50 +162,50 @@ func (split) obfuscate(data []byte) *ast.BlockStmt {
 			Tok: token.VAR,
 			Specs: []ast.Spec{
 				&ast.ValueSpec{
-					Names: []*ast.Ident{ah.Ident("data")},
-					Type:  &ast.ArrayType{Elt: ah.Ident("byte")},
+					Names: []*ast.Ident{ast.NewIdent("data")},
+					Type:  &ast.ArrayType{Elt: ast.NewIdent("byte")},
 				},
 			},
 		}},
 		&ast.AssignStmt{
-			Lhs: []ast.Expr{ah.Ident("i")},
+			Lhs: []ast.Expr{ast.NewIdent("i")},
 			Tok: token.DEFINE,
 			Rhs: []ast.Expr{ah.IntLit(indexes[0])},
 		},
 		&ast.AssignStmt{
-			Lhs: []ast.Expr{ah.Ident("decryptKey")},
+			Lhs: []ast.Expr{ast.NewIdent("decryptKey")},
 			Tok: token.DEFINE,
 			Rhs: []ast.Expr{ah.IntLit(int(decryptKeyInitial))},
 		},
 		&ast.ForStmt{
 			Init: &ast.AssignStmt{
-				Lhs: []ast.Expr{ah.Ident("counter")},
+				Lhs: []ast.Expr{ast.NewIdent("counter")},
 				Tok: token.DEFINE,
 				Rhs: []ast.Expr{ah.IntLit(0)},
 			},
 			Cond: &ast.BinaryExpr{
-				X:  ah.Ident("i"),
+				X:  ast.NewIdent("i"),
 				Op: token.NEQ,
 				Y:  ah.IntLit(indexes[len(indexes)-1]),
 			},
 			Post: &ast.IncDecStmt{
-				X:   ah.Ident("counter"),
+				X:   ast.NewIdent("counter"),
 				Tok: token.INC,
 			},
 			Body: ah.BlockStmt(
 				&ast.AssignStmt{
-					Lhs: []ast.Expr{ah.Ident("decryptKey")},
+					Lhs: []ast.Expr{ast.NewIdent("decryptKey")},
 					Tok: token.XOR_ASSIGN,
 					Rhs: []ast.Expr{
 						&ast.BinaryExpr{
-							X:  ah.Ident("i"),
+							X:  ast.NewIdent("i"),
 							Op: token.MUL,
-							Y:  ah.Ident("counter"),
+							Y:  ast.NewIdent("counter"),
 						},
 					},
 				},
 				&ast.SwitchStmt{
-					Tag:  ah.Ident("i"),
+					Tag:  ast.NewIdent("i"),
 					Body: ah.BlockStmt(shuffleStmts(switchCases...)...),
 				}),
 		},

--- a/internal/literals/swap.go
+++ b/internal/literals/swap.go
@@ -34,7 +34,7 @@ func positionsToSlice(data []int) *ast.CompositeLit {
 	arr := &ast.CompositeLit{
 		Type: &ast.ArrayType{
 			Len: &ast.Ellipsis{}, // Performance optimization
-			Elt: ah.Ident(getIndexType(len(data))),
+			Elt: ast.NewIdent(getIndexType(len(data))),
 		},
 		Elts: []ast.Expr{},
 	}
@@ -74,44 +74,44 @@ func (swap) obfuscate(data []byte) *ast.BlockStmt {
 
 	return ah.BlockStmt(
 		&ast.AssignStmt{
-			Lhs: []ast.Expr{ah.Ident("data")},
+			Lhs: []ast.Expr{ast.NewIdent("data")},
 			Tok: token.DEFINE,
 			Rhs: []ast.Expr{ah.DataToByteSlice(data)},
 		},
 		&ast.AssignStmt{
-			Lhs: []ast.Expr{ah.Ident("positions")},
+			Lhs: []ast.Expr{ast.NewIdent("positions")},
 			Tok: token.DEFINE,
 			Rhs: []ast.Expr{positionsToSlice(positions)},
 		},
 		&ast.ForStmt{
 			Init: &ast.AssignStmt{
-				Lhs: []ast.Expr{ah.Ident("i")},
+				Lhs: []ast.Expr{ast.NewIdent("i")},
 				Tok: token.DEFINE,
 				Rhs: []ast.Expr{ah.IntLit(0)},
 			},
 			Cond: &ast.BinaryExpr{
-				X:  ah.Ident("i"),
+				X:  ast.NewIdent("i"),
 				Op: token.LSS,
 				Y:  ah.IntLit(len(positions)),
 			},
 			Post: &ast.AssignStmt{
-				Lhs: []ast.Expr{ah.Ident("i")},
+				Lhs: []ast.Expr{ast.NewIdent("i")},
 				Tok: token.ADD_ASSIGN,
 				Rhs: []ast.Expr{ah.IntLit(2)},
 			},
 			Body: ah.BlockStmt(
 				&ast.AssignStmt{
-					Lhs: []ast.Expr{ah.Ident("localKey")},
+					Lhs: []ast.Expr{ast.NewIdent("localKey")},
 					Tok: token.DEFINE,
 					Rhs: []ast.Expr{&ast.BinaryExpr{
 						X: &ast.BinaryExpr{
-							X:  ah.CallExpr(ah.Ident("byte"), ah.Ident("i")),
+							X:  ah.CallExpr(ast.NewIdent("byte"), ast.NewIdent("i")),
 							Op: token.ADD,
-							Y: ah.CallExpr(ah.Ident("byte"), &ast.BinaryExpr{
-								X:  ah.IndexExpr("positions", ah.Ident("i")),
+							Y: ah.CallExpr(ast.NewIdent("byte"), &ast.BinaryExpr{
+								X:  ah.IndexExpr("positions", ast.NewIdent("i")),
 								Op: token.XOR,
 								Y: ah.IndexExpr("positions", &ast.BinaryExpr{
-									X:  ah.Ident("i"),
+									X:  ast.NewIdent("i"),
 									Op: token.ADD,
 									Y:  ah.IntLit(1),
 								}),
@@ -123,9 +123,9 @@ func (swap) obfuscate(data []byte) *ast.BlockStmt {
 				},
 				&ast.AssignStmt{
 					Lhs: []ast.Expr{
-						ah.IndexExpr("data", ah.IndexExpr("positions", ah.Ident("i"))),
+						ah.IndexExpr("data", ah.IndexExpr("positions", ast.NewIdent("i"))),
 						ah.IndexExpr("data", ah.IndexExpr("positions", &ast.BinaryExpr{
-							X:  ah.Ident("i"),
+							X:  ast.NewIdent("i"),
 							Op: token.ADD,
 							Y:  ah.IntLit(1),
 						})),
@@ -136,17 +136,17 @@ func (swap) obfuscate(data []byte) *ast.BlockStmt {
 							op,
 							ah.IndexExpr("data",
 								ah.IndexExpr("positions", &ast.BinaryExpr{
-									X:  ah.Ident("i"),
+									X:  ast.NewIdent("i"),
 									Op: token.ADD,
 									Y:  ah.IntLit(1),
 								}),
 							),
-							ah.Ident("localKey"),
+							ast.NewIdent("localKey"),
 						),
 						operatorToReversedBinaryExpr(
 							op,
-							ah.IndexExpr("data", ah.IndexExpr("positions", ah.Ident("i"))),
-							ah.Ident("localKey"),
+							ah.IndexExpr("data", ah.IndexExpr("positions", ast.NewIdent("i"))),
+							ast.NewIdent("localKey"),
 						),
 					},
 				},

--- a/main_test.go
+++ b/main_test.go
@@ -289,14 +289,14 @@ func generateLiterals(ts *testscript.TestScript, neg bool, args []string) {
 	var statements []ast.Stmt
 	for i := 0; i < literalCount; i++ {
 		literal := generateStringLit()
-		statements = append(statements, ah.ExprStmt(ah.CallExpr(ah.Ident("println"), literal)))
+		statements = append(statements, ah.ExprStmt(ah.CallExpr(ast.NewIdent("println"), literal)))
 	}
 
 	file := &ast.File{
-		Name: ah.Ident("main"),
+		Name: ast.NewIdent("main"),
 		Decls: []ast.Decl{
 			&ast.FuncDecl{
-				Name: ah.Ident(funcName),
+				Name: ast.NewIdent(funcName),
 				Type: &ast.FuncType{
 					Params: &ast.FieldList{},
 				},

--- a/runtime_strip.go
+++ b/runtime_strip.go
@@ -143,7 +143,7 @@ func removeImport(importPath string, specs []ast.Spec) []ast.Spec {
 }
 
 var hidePrintDecl = &ast.FuncDecl{
-	Name: ah.Ident("hidePrint"),
+	Name: ast.NewIdent("hidePrint"),
 	Type: &ast.FuncType{Params: &ast.FieldList{
 		List: []*ast.Field{{
 			Names: []*ast.Ident{{Name: "args"}},
@@ -158,16 +158,16 @@ var hidePrintDecl = &ast.FuncDecl{
 var parsedebugvarsStmts = ah.BlockStmt(
 	&ast.AssignStmt{
 		Lhs: []ast.Expr{&ast.SelectorExpr{
-			X:   ah.Ident("debug"),
-			Sel: ah.Ident("cgocheck"),
+			X:   ast.NewIdent("debug"),
+			Sel: ast.NewIdent("cgocheck"),
 		}},
 		Tok: token.ASSIGN,
 		Rhs: []ast.Expr{ah.IntLit(1)},
 	},
 	&ast.AssignStmt{
 		Lhs: []ast.Expr{&ast.SelectorExpr{
-			X:   ah.Ident("debug"),
-			Sel: ah.Ident("invalidptr"),
+			X:   ast.NewIdent("debug"),
+			Sel: ast.NewIdent("invalidptr"),
 		}},
 		Tok: token.ASSIGN,
 		Rhs: []ast.Expr{ah.IntLit(1)},


### PR DESCRIPTION
No point in having around a helper method that has been implemented for
us by `go/ast`