### PR TITLE
warn when a public package imports a private package

### DIFF
--- a/main.go
+++ b/main.go
@@ -425,7 +425,7 @@ func mainErr(args []string) error {
 			return fmt.Errorf("GOPRIVATE=%q does not match any packages to be built", envGoPrivate)
 		}
 		for path, pkg := range listedPackages {
-			if pkg.private == true {
+			if pkg.private {
 				continue
 			}
 			for _, depPath := range pkg.Deps {

--- a/testdata/scripts/goprivate.txt
+++ b/testdata/scripts/goprivate.txt
@@ -1,11 +1,15 @@
 env GOPRIVATE=match-absolutely/nothing
-! garble build -o bin ./standalone
-stderr 'does not match any packages'
+! garble build -o=out ./standalone
+stderr '^GOPRIVATE="match-absolutely/nothing" does not match any packages to be built$'
+
+env GOPRIVATE=test/main/imported
+! garble build ./importer
+stderr '^public package "test/main/importer" can''t depend on obfuscated package "test/main/imported" \(matched via GOPRIVATE="test/main/imported"\)$'
 
 [short] stop
 
 env GOPRIVATE='*'
-garble build  -o bin ./standalone
+garble build -o=out ./standalone
 
 -- go.mod --
 module test/main
@@ -13,3 +17,13 @@ module test/main
 package main
 
 func main() {}
+-- importer/importer.go --
+package importer
+
+import "test/main/imported"
+
+var _ = imported.Name
+-- imported/imported.go --
+package imported
+
+var Name = "value"


### PR DESCRIPTION
That is, a package that is built without obfuscation imports an
obfuscated package. This will result in confusing compilation error
messages, because the importer can't find the exported names from the
imported package by their non-obfuscated names:

	> ! garble build ./importer
	[stderr]
	# test/main/importer
	importer/importer.go:5:9: undefined: imported.Name
	exit status 2

Instead, detect this bad input case and provide a nice error:

	public package "test/main/importer" can't depend on obfuscated package "test/main/imported" (matched via GOPRIVATE="test/main/imported")

For now, this is by design. It also makes little sense for a public
package to import an obfuscated package in general, because the public
package would have to leak details about the private package's API and
behavior.

While at it, fix a quirk where we thought the unsafe package could be
private. It can't be, because the runtime package is always public and
it imports the runtime package:

	public package "internal/bytealg" can't depend on obfuscated package "unsafe" (matched via GOPRIVATE="*")

Instead of trying to obfuscate "unsafe" and doing nothing, simply add it
to the neverPrivate list, which is also a better name than
"privateBlacklist" (for #169).

Fixes #164.