### PR TITLE
testdata: don't let tests rely on rewriting mod files

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -64,6 +64,7 @@ func TestScripts(t *testing.T) {
 			env.Vars = append(env.Vars,
 				"GOPROXY="+proxyURL,
 				"GONOSUMDB=*",
+				"GOFLAGS=-mod=readonly", // TODO(mvdan): remove once we switch to Go 1.16
 				"gofullversion="+runtime.Version(),
 			)
 			bindir := filepath.Join(env.WorkDir, ".bin")

--- a/testdata/scripts/asm.txt
+++ b/testdata/scripts/asm.txt
@@ -18,6 +18,8 @@ cmp stderr main.stderr
 
 -- go.mod --
 module test/main
+
+go 1.15
 -- main.go --
 package main
 

--- a/testdata/scripts/basic.txt
+++ b/testdata/scripts/basic.txt
@@ -57,6 +57,8 @@ binsubstr main$exe 'main.go' 'globalVar' 'globalFunc' $gofullversion
 
 -- go.mod --
 module test/mainfoo
+
+go 1.15
 -- main.go --
 package main
 

--- a/testdata/scripts/cgo.txt
+++ b/testdata/scripts/cgo.txt
@@ -18,6 +18,8 @@ cmp stderr main.stderr
 
 -- go.mod --
 module test/main
+
+go 1.15
 -- main.go --
 package main
 

--- a/testdata/scripts/debugdir.txt
+++ b/testdata/scripts/debugdir.txt
@@ -17,6 +17,8 @@ garble -debugdir ./test1 build -v
 
 -- go.mod --
 module test/main
+
+go 1.15
 -- main.go --
 package main
 

--- a/testdata/scripts/goprivate.txt
+++ b/testdata/scripts/goprivate.txt
@@ -13,6 +13,8 @@ garble build -o=out ./standalone
 
 -- go.mod --
 module test/main
+
+go 1.15
 -- standalone/main.go --
 package main
 

--- a/testdata/scripts/implement.txt
+++ b/testdata/scripts/implement.txt
@@ -8,6 +8,8 @@ cmp stderr main.stderr
 
 -- go.mod --
 module test/main
+
+go 1.15
 -- main.go --
 package main
 

--- a/testdata/scripts/imports.txt
+++ b/testdata/scripts/imports.txt
@@ -1,7 +1,10 @@
 # Note that this is the only test with a module where we rely on the detection
 # of GOPRIVATE.
+# Also note that, since this is the only test using "real" external modules
+# fetched via GOPROXY, go.mod and go.sum should declare the dependencies.
 
 garble build -tags buildtag
+exec cat go.sum
 exec ./main
 cmp stdout main.stdout
 
@@ -29,6 +32,17 @@ cmp stdout main.stdout
 
 -- go.mod --
 module test/main
+
+go 1.15
+
+require rsc.io/quote v1.5.2
+-- go.sum --
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c h1:pvCbr/wm8HzDD3fVywevekufpn6tCGPY3spdHeZJEsw=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+rsc.io/quote v1.5.2 h1:3fEykkD9k7lYzXqCYrwGAf7iNhbk4yCjHmKBN9td4L0=
+rsc.io/quote v1.5.2/go.mod h1:LzX7hefJvL54yjefDEDHNONDjII0t9xZLPXsUe+TKr0=
+rsc.io/sampler v1.3.0 h1:HLGR/BgEtI3r0uymSP/nl2uPLsUnNJX8toRyhfpBTII=
+rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 -- main.go --
 package main
 

--- a/testdata/scripts/init.txt
+++ b/testdata/scripts/init.txt
@@ -12,6 +12,8 @@ cmp stderr main.stderr
 
 -- go.mod --
 module test/main
+
+go 1.15
 -- main.go --
 package main
 

--- a/testdata/scripts/ldflags.txt
+++ b/testdata/scripts/ldflags.txt
@@ -20,6 +20,8 @@ binsubstr main$exe 'unexportedVersion'
 
 -- go.mod --
 module domain.test/main
+
+go 1.15
 -- main.go --
 package main
 

--- a/testdata/scripts/literals.txt
+++ b/testdata/scripts/literals.txt
@@ -51,6 +51,8 @@ grep '^\s+type \w+ func\(byte\) \w+$' .obf-src/main/extraLiterals.go
 
 -- go.mod --
 module test/main
+
+go 1.15
 -- main.go --
 package main
 

--- a/testdata/scripts/modinfo.txt
+++ b/testdata/scripts/modinfo.txt
@@ -14,6 +14,8 @@ binsubstr main$exe '(devel)'
 
 -- go.mod --
 module test/main
+
+go 1.15
 -- main.go --
 package main
 

--- a/testdata/scripts/plugin.txt
+++ b/testdata/scripts/plugin.txt
@@ -28,6 +28,8 @@ cmp stderr main.stderr
 
 -- go.mod --
 module test/main
+
+go 1.15
 -- plugin/main.go --
 package main
 

--- a/testdata/scripts/seed.txt
+++ b/testdata/scripts/seed.txt
@@ -39,6 +39,8 @@ stderr .
 
 -- go.mod --
 module test/main
+
+go 1.15
 -- main.go --
 package main
 

--- a/testdata/scripts/syntax.txt
+++ b/testdata/scripts/syntax.txt
@@ -1,6 +1,7 @@
 env GOPRIVATE='test/main,private.source/*'
 
 garble build -tags directives
+exec cat go.mod
 exec ./main$exe
 cmp stderr main.stderr
 
@@ -19,6 +20,8 @@ binsubstr main$exe 'globalVar' # 'globalType' only matches on go < 1.15
 
 -- extra/go.mod --
 module "private.source/extra"
+
+go 1.15
 -- extra/extra.go --
 package extra
 
@@ -28,8 +31,12 @@ func Func() string {
 -- go.mod --
 module test/main
 
+go 1.15
+
 // We include an extra module to obfuscate, included in the same original source
 // code via a replace directive.
+require private.source/extra v0.0.0-00010101000000-000000000000
+
 replace private.source/extra => ./extra
 -- main.go --
 package main

--- a/testdata/scripts/test.txt
+++ b/testdata/scripts/test.txt
@@ -19,6 +19,8 @@ stdout 'PASS.*TestFoo'
 
 -- go.mod --
 module test/bar
+
+go 1.15
 -- bar.go --
 package bar
 

--- a/testdata/scripts/tiny.txt
+++ b/testdata/scripts/tiny.txt
@@ -22,6 +22,8 @@ stderr 'panic: oh noes'
 
 -- go.mod --
 module test/main
+
+go 1.15
 -- main.go --
 package main
 


### PR DESCRIPTION
In Go 1.15, if a dependency is required but not listed in go.mod/go.sum,
it's resolved and added automatically.

This is changing in 1.16. From that release, one will have to explicitly
update the mod files via 'go mod tidy' or 'go get'.

To get ahead of the curve, start using -mod=readonly to get the same
behavior in 1.15, and fix all existing tests.

The only tests that failed were imports.txt and syntax.txt, the only
ones to require other modules. But since we're here, let's add the 'go'
line to all go.mod files as well.