### PR TITLE
add test case for ImportMap support

### DIFF
--- a/testdata/scripts/goprivate.txt
+++ b/testdata/scripts/goprivate.txt
@@ -8,6 +8,9 @@ stderr '^public package "test/main/importer" can''t depend on obfuscated package
 
 [short] stop
 
+# Try garbling all of std.
+# This used to fail since the "net" import causes 'go list -json' to output
+# ImportMap, since "net" imports packages vendored in std.
 env GOPRIVATE='*'
 garble build -o=out ./standalone
 
@@ -17,6 +20,9 @@ module test/main
 go 1.15
 -- standalone/main.go --
 package main
+
+// Blocked until https://github.com/Binject/debug/issues/17 is fixed.
+// import _ "net"
 
 func main() {}
 -- importer/importer.go --


### PR DESCRIPTION
We also update the "original types importer" to support ImportMap.

The test now gets further along, no longer getting stuck on "path not
found in listed packages". Instead, we get stuck on:

	error parsing importcfg: <...>/importcfg:2: unknown directive "importmap"

This bug has been filed at https://github.com/Binject/debug/issues/17.
Until it's fixed, we can't really proceed on #146, so the net import in
the test file (which triggers this case) is commented out for now.

Updates #146.