### PR TITLE
testdata: avoid messing with the host's mod cache

### DIFF
--- a/testdata/scripts/imports.txt
+++ b/testdata/scripts/imports.txt
@@ -3,8 +3,20 @@
 # Also note that, since this is the only test using "real" external modules
 # fetched via GOPROXY, go.mod and go.sum should declare the dependencies.
 
+# For now, use a throwaway module download cache instead of the host machine's.
+# Usually it would be fine to reuse the host's, since we expose exact copies of
+# some external modules in a local proxy, allowing 'go test' to work offline.
+# However, for some reason, we end up with different hashes of the code for
+# modules like rsc.io/quote, and it's unclear why. It might be a txtar-addmod bug.
+# In any case, not worth our time to investigate right now, and "downloading"
+# modules is instant since we just copy a handful of files.
+#
+# To reproduce the issue, remove the env line and run:
+#
+#    go clean -modcache && go get -d rsc.io/quote@v1.5.2 && go test -short
+env GOMODCACHE=$WORK/modcache
+
 garble build -tags buildtag
-exec cat go.sum
 exec ./main
 cmp stdout main.stdout
 

--- a/testdata/scripts/syntax.txt
+++ b/testdata/scripts/syntax.txt
@@ -1,7 +1,6 @@
 env GOPRIVATE='test/main,private.source/*'
 
 garble build -tags directives
-exec cat go.mod
 exec ./main$exe
 cmp stderr main.stderr
 


### PR DESCRIPTION
It turns out that the modules we include in testdata/mod via
txtar-addmod don't result in the same h1 hash that one gets when using
proxy.golang.org.

As proof:

	$ go clean -modcache && go get -d rsc.io/quote@v1.5.2 && go test -short
	[...]
	--- FAIL: TestScripts/imports (0.06s)
		> garble build -tags buildtag
		go list error: exit status 1: verifying rsc.io/quote@v1.5.2: checksum mismatch
		    downloaded: h1:w5fcysjrx7yqtD/aO+QwRjYZOKnaM9Uh2b40tElTs3Y=
		    go.sum:     h1:3fEykkD9k7lYzXqCYrwGAf7iNhbk4yCjHmKBN9td4L0=

The added comment explains the situation in detail.

For now, simply work around the issue by not sharing GOMODCACHE with the
host.