### PR TITLE
fix garbling names belonging to indirect imports

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -18,8 +18,8 @@ import (
 
 const buildIDSeparator = "/"
 
-// actionID returns the action ID half of a build ID, the first element.
-func actionID(buildID string) string {
+// splitActionID returns the action ID half of a build ID, the first element.
+func splitActionID(buildID string) string {
 	i := strings.Index(buildID, buildIDSeparator)
 	if i < 0 {
 		return buildID
@@ -27,12 +27,12 @@ func actionID(buildID string) string {
 	return buildID[:i]
 }
 
-// contentID returns the content ID half of a build ID, the last element.
-func contentID(buildID string) string {
+// splitContentID returns the content ID half of a build ID, the last element.
+func splitContentID(buildID string) string {
 	return buildID[strings.LastIndex(buildID, buildIDSeparator)+1:]
 }
 
-// decodeHash isthe opposite of hashToString, but with a panic for error
+// decodeHash is the opposite of hashToString, but with a panic for error
 // handling since it should never happen.
 func decodeHash(str string) []byte {
 	h, err := base64.RawURLEncoding.DecodeString(str)
@@ -59,7 +59,7 @@ func alterToolVersion(tool string, args []string) error {
 	var toolID []byte
 	if f[2] == "devel" {
 		// On the development branch, use the content ID part of the build ID.
-		toolID = decodeHash(contentID(f[len(f)-1]))
+		toolID = decodeHash(splitContentID(f[len(f)-1]))
 	} else {
 		// For a release, the output is like: "compile version go1.9.1 X:framepointer".
 		// Use the whole line.
@@ -96,7 +96,7 @@ func ownContentID(toolID []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	ownID := decodeHash(contentID(buildID))
+	ownID := decodeHash(splitContentID(buildID))
 
 	// Join the two content IDs together into a single base64-encoded sha256
 	// sum. This includes the original tool's content ID, and garble's own

--- a/shared.go
+++ b/shared.go
@@ -16,8 +16,11 @@ import (
 
 // shared this data is shared between the different garble processes
 type shared struct {
-	Options        options
-	ListedPackages listedPackages
+	ExecPath   string   // absolute path to the garble binary being used
+	BuildFlags []string // build flags fed to the original "garble ..." command
+
+	Options        options        // garble options being used, i.e. our own flags
+	ListedPackages listedPackages // non-garbled view of all packages to build
 }
 
 var cache *shared
@@ -146,9 +149,9 @@ type listedPackage struct {
 
 // setListedPackages gets information about the current package
 // and all of its dependencies
-func setListedPackages(flags, patterns []string) error {
+func setListedPackages(patterns []string) error {
 	args := []string{"list", "-json", "-deps", "-export"}
-	args = append(args, flags...)
+	args = append(args, cache.BuildFlags...)
 	args = append(args, patterns...)
 	cmd := exec.Command("go", args...)
 

--- a/testdata/scripts/imports.txt
+++ b/testdata/scripts/imports.txt
@@ -60,8 +60,8 @@ package main
 
 import (
 	"fmt"
-	"strings"
 	"reflect"
+	"strings"
 
 	"test/main/imported"
 
@@ -75,8 +75,9 @@ func main() {
 	fmt.Println(imported.ImportedType(3))
 	fmt.Println(imported.ReflectInDefinedVar.ExportedField2)
 	fmt.Println(imported.ReflectInDefined{ExportedField2: 5})
-	fmt.Println(imported.NormalStruct{SharedName: 3})
-
+	normal := imported.NormalStruct{SharedName: 3}
+	normal.IndirectStruct.Field = 23
+	fmt.Println(normal)
 	printfWithoutPackage("%T\n", imported.ReflectTypeOf(2))
 	printfWithoutPackage("%T\n", imported.ReflectTypeOfIndirect(4))
 
@@ -112,7 +113,10 @@ func init() { fmt.Println("buildtag init func") }
 -- imported/imported.go --
 package imported
 
-import "reflect"
+import (
+	"reflect"
+	"test/main/imported/indirect"
+)
 
 var ImportedVar = "imported var value"
 
@@ -131,19 +135,19 @@ type ReflectTypeOfIndirect int
 var _ = reflect.TypeOf(new([]*ReflectTypeOfIndirect))
 
 type ReflectValueOf struct {
-	ExportedField   string
+	ExportedField string
 
 	unexportedField string
 }
 
-func (r *ReflectValueOf) ExportedMethodName() string { return "method: "+r.ExportedField }
+func (r *ReflectValueOf) ExportedMethodName() string { return "method: " + r.ExportedField }
 
 var ReflectValueOfVar = ReflectValueOf{ExportedField: "abc"}
 
 var _ = reflect.TypeOf(ReflectValueOfVar)
 
 type ReflectInDefined struct {
-	ExportedField2   int
+	ExportedField2 int
 
 	unexportedField2 int
 }
@@ -155,12 +159,20 @@ var _ = reflect.TypeOf(ReflectInDefinedVar)
 const SharedName = 2
 
 type NormalStruct struct {
-	SharedName   int
+	SharedName            int
+	IndirectStruct        indirect.Indirect
 	normalUnexportedField int
 }
 
 // ImportedType comes after the calls to reflect, to ensure no false positives.
 type ImportedType int
+
+-- imported/indirect/indirect.go --
+package indirect
+
+type Indirect struct {
+	Field int
+}
 
 -- main.stdout --
 buildtag init func
@@ -170,7 +182,7 @@ x
 3
 9000
 {5 0}
-{3 0}
+{3 {23} 0}
 ReflectTypeOf
 ReflectTypeOfIndirect
 ReflectValueOf{ExportedField:"abc", unexportedField:""}


### PR DESCRIPTION
main.go includes a lengthy comment that documents this edge case, why it
happened, and how we are fixing it. To summarize, we should no longer
error with a build error in those cases. Read the comment for details.

A few other minor changes were done to allow writing this patch.

First, the actionID and contentID funcs were renamed, since they started
to collide with variable names.

Second, the logging has been improved a bit, which allowed me to debug
the issue.

Third, the "cache" global shared by all garble sub-processes now
includes the necessary parameters to run "go list -toolexec", including
the path to garble and the build flags being used.

Thanks to lu4p for writing a test case, which also applied gofmt to that
testdata Go file.

Fixes #180.
Closes #181, since it includes its test case.