### PR TITLE
do not try to obfuscate huge literals

### DIFF
--- a/testdata/scripts/literals.txt
+++ b/testdata/scripts/literals.txt
@@ -21,8 +21,11 @@ exec ./main$exe
 cmp stderr main.stderr
 binsubstr main$exe 'Lorem' 'dolor' 'second assign' 'First Line' 'Second Line' 'map value' 'to obfuscate' 'also obfuscate' 'stringTypeField String'
 
-# Generate and write random literals into a separate file
-generate-literals extraLiterals.go 100 printExtraLiterals
+# Generate and write random literals into a separate file.
+# Some of them will be huge; assuming that we don't try to obfuscate them, the
+# test should generally run in under a second. If this test hangs for over ten
+# seconds, it means we're trying to obfuscate them.
+generate-literals extra_literals.go
 
 # Also check that the binary is different from previous builds.
 rm main$exe
@@ -35,19 +38,19 @@ cmp stderr main.stderr
 # Check obfuscators
 
 # Xor obfuscator. Detect a[i] = a[i] (^|-|+) b[i]
-grep '^\s+\w+\[\w+\] = \w+\[\w+\] [\^\-+] \w+$' .obf-src/main/extraLiterals.go
+grep '^\s+\w+\[\w+\] = \w+\[\w+\] [\^\-+] \w+$' .obf-src/main/extra_literals.go
 
 # Swap obfuscator. Detect [...]byte|uint16|uint32|uint64{...}
-grep '^\s+\w+ := \[\.{3}\](byte|uint16|uint32|uint64)\{[0-9\s,]+\}$' .obf-src/main/extraLiterals.go
+grep '^\s+\w+ := \[\.{3}\](byte|uint16|uint32|uint64)\{[0-9\s,]+\}$' .obf-src/main/extra_literals.go
 
 # Split obfuscator. Detect decryptKey ^= i * counter
-grep '^\s+\w+ \^= \w+ \* \w+$' .obf-src/main/extraLiterals.go
+grep '^\s+\w+ \^= \w+ \* \w+$' .obf-src/main/extra_literals.go
 
 # XorShuffle obfuscator. Detect data = append(data, x (^|-|+) y...)
-grep '^\s+\w+ = append\(\w+,(\s+\w+\[\d+\][\^\-+]\w+\[\d+\],?)+\)$' .obf-src/main/extraLiterals.go
+grep '^\s+\w+ = append\(\w+,(\s+\w+\[\d+\][\^\-+]\w+\[\d+\],?)+\)$' .obf-src/main/extra_literals.go
 
 # XorSeed obfuscator. Detect type decFunc func(byte) decFunc
-grep '^\s+type \w+ func\(byte\) \w+$' .obf-src/main/extraLiterals.go
+grep '^\s+type \w+ func\(byte\) \w+$' .obf-src/main/extra_literals.go
 
 -- go.mod --
 module test/main


### PR DESCRIPTION
It's common for asset bundling code generators to produce huge literals,
for example in strings. Our literal obfuscators are meant for relatively
small string-like literals that a human would write, such as URLs, file
paths, and English text.

I ran some quick experiments, and it seems like "garble build -literals"
appears to hang trying to obfuscate literals starting at 5-20KiB. It's
not really hung; it's just doing a lot of busy work obfuscating those
literals. The code it produces is also far from ideal, so it also takes
some time to finally compile.

The generated code also led to crashes. For example, using "garble build
-literals -tiny" on a package containing literals of over a megabyte,
our use of asthelper to remove comments and shuffle line numbers could
run out of stack memory.

This all points in one direction: we never designed "-literals" to deal
with large sizes. Set a source-code-size limit of 2KiB.

We alter the literals.txt test as well, to include a few 128KiB string
literals. Before this fix, "go test" would seemingly hang on that test
for over a minute (I did not wait any longer). With the fix, those large
literals are not obfuscated, so the test ends in its usual 1-3s.

As said in the const comment, I don't believe any of this is a big
problem. Come Go 1.16, most developers should stop using asset-bundling
code generators and use go:embed instead. If we wanted to somehow
obfuscate those, it would be an entirely separate feature.

And, if someone wants to work on obfuscating truly large literals for
any reason, we need good tests and benchmarks to ensure garble does not
consume CPU for minutes or run out of memory.

I also simplified the generate-literals test command. The only argument
that matters to the script is the filename, since it's used later on.

Fixes #178.