### PR TITLE
all: use better names than "blacklist", and docs

### DIFF
--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -473,8 +473,7 @@ func garbleSymbols(am *goobj2.ArchiveMember, privImports privateImports, garbled
 				continue
 			}
 
-			// skip local asm symbols. For some reason garbling these breaks things
-			// add the symbol name to a blacklist, so we don't garble related symbols
+			// Skip local asm symbols. For some reason garbling these breaks things.
 			// TODO: don't add duplicates
 			if s.Kind == goobj2.SABIALIAS {
 				if parts := strings.SplitN(s.Name, ".", 2); parts[0] == "main" {


### PR DESCRIPTION
The three transformer map fields are now very well documented, which was
badly needed for anyone trying to understand the source code.

ignoreObjects is also a better field name than blacklist, as it says
what the map is indexed by (types.Object) and what we do with those:
ignore them when we obfuscate code.

The rewriting of go:linkname directives is moved to a separate func, so
that we can name that func from the docs.

Finally, the docs are overall improved a bit, as I was re-tracing all
the pieces of code that used the ambiguous "blacklist" terminology.

Fixes #169.