### PR TITLE
If the seed is random and the build fails, print the seed

### DIFF
--- a/internal/literals/obfuscators.go
+++ b/internal/literals/obfuscators.go
@@ -4,13 +4,11 @@
 package literals
 
 import (
-	cryptrand "crypto/rand"
 	"fmt"
 	"go/ast"
 	"go/token"
 	mathrand "math/rand"
 	"os"
-	"strings"
 )
 
 // obfuscator takes a byte slice and converts it to a ast.BlockStmt
@@ -35,16 +33,8 @@ var (
 
 // genRandBytes return a random []byte with the length of size.
 func genRandBytes(buffer []byte) {
-	if strings.HasPrefix(envGarbleSeed, "random;") {
-		_, err := cryptrand.Read(buffer)
-		if err != nil {
-			panic(fmt.Sprintf("couldn't generate random key:  %v", err))
-		}
-	} else {
-		_, err := mathrand.Read(buffer)
-		if err != nil {
-			panic(fmt.Sprintf("couldn't generate random key:  %v", err))
-		}
+	if _, err := mathrand.Read(buffer); err != nil {
+		panic(fmt.Sprintf("couldn't generate random key:  %v", err))
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -170,6 +170,9 @@ func main1() int {
 		case errJustExit:
 		default:
 			fmt.Fprintln(os.Stderr, err)
+			if flagSeed == "random" {
+				fmt.Fprintf(os.Stderr, "random seed: %s\n", base64.RawStdEncoding.EncodeToString(opts.Seed))
+			}
 		}
 		return 1
 	}
@@ -238,7 +241,7 @@ How to install Go: https://golang.org/doc/install
 }
 
 func mainErr(args []string) error {
-	// If we recognise an argument, we're not running within -toolexec.
+	// If we recognize an argument, we're not running within -toolexec.
 	switch cmd := args[0]; cmd {
 	case "help":
 		return flag.ErrHelp


### PR DESCRIPTION
Fixes #212. Also makes literal obfuscation always use `math/rand` to make it deterministic, even when `-seed=random` is passed.