### PR TITLE
share a single temporary directory between all processes

### DIFF
--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -153,7 +153,7 @@ func extractDebugObfSrc(pkgPath string, pkg *goobj2.Package) error {
 // It returns the path to the modified main object file, to be used for linking.
 // We also return a map of how the imports were garbled, as well as the private
 // name map recovered from the archive files, so that we can amend -X flags.
-func obfuscateImports(objPath, tempDir string, importMap goobj2.ImportMap) (garbledObj string, garbledImports, privateNameMap map[string]string, _ error) {
+func obfuscateImports(objPath string, importMap goobj2.ImportMap) (garbledObj string, garbledImports, privateNameMap map[string]string, _ error) {
 	mainPkg, err := goobj2.Parse(objPath, "main", importMap)
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("error parsing main objfile: %v", err)
@@ -274,7 +274,7 @@ func obfuscateImports(objPath, tempDir string, importMap goobj2.ImportMap) (garb
 		// An archive under the temporary file. Note that
 		// ioutil.TempFile creates a file to ensure no collisions, so we
 		// simply use its name after closing the file.
-		tempObjFile, err := ioutil.TempFile(tempDir, "pkg.*.a")
+		tempObjFile, err := ioutil.TempFile(sharedTempDir, "pkg.*.a")
 		if err != nil {
 			return "", nil, nil, fmt.Errorf("creating temp file: %v", err)
 		}


### PR DESCRIPTION
Each compile and link sub-process created its own temporary directory,
to be cleaned up shortly after. Moreover, we also had the global
gob-encoded temporary file.

Instead, place all of those under a single, start-to-end temporary
directory. This is cleaner for the end user, and easier to maintain for
us.

A big plus is that we can also get rid of the confusing deferred global,
as it was mostly used to clean up these extra temp dirs. The only
remaining use was post-compile code, which is now an explicit func
returned by each "transform" func.

While at it, clean up the math/rand seeding code a bit and add a debug
log line, and stop shadowing a cmd string with a cmd *exec.Cmd.

Fixes #147.