### PR TITLE
better document and position the hash base64 encoding

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,8 +87,6 @@ var (
 	fset          = token.NewFileSet()
 	sharedTempDir = os.Getenv("GARBLE_SHARED")
 
-	nameCharset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_z"
-	b64         = base64.NewEncoding(nameCharset)
 	printConfig = printer.Config{Mode: printer.RawFormat}
 
 	// origImporter is a go/types importer which uses the original versions


### PR DESCRIPTION
We now document why we use a custom base64 charset.

The old "b64" name was also too generic, so it might have been misused
for other purposes.