### PR TITLE
testdata: fix flakiness of tiny.txt on Windows

### DIFF
--- a/testdata/scripts/tiny.txt
+++ b/testdata/scripts/tiny.txt
@@ -5,7 +5,7 @@ garble -tiny build
 ! binsubstr main$exe 'main.go' 'fmt/print.go'
 env GODEBUG='allocfreetrace=1,gcpacertrace=1,gctrace=1,inittrace=1,scavenge=1,scavtrace=1,scheddetail=1,schedtrace=10'
 ! exec ./main$exe
-stderr '^\(0x[\d\w]{6,8},0x[\d\w]{6,8}\)' # interfaces/pointers print correctly
+stderr '^\(0x[\d\w]{4,8},0x[\d\w]{4,8}\)' # interfaces/pointers print correctly
 # TODO: Make -tiny remove all line information again.
 # Right now, we reset each declaration's start line to 1.
 # Better than nothing, but we could still make *all* line numbers 1.


### PR DESCRIPTION
(see commit message)