### PR TITLE
Literals: Skip constants with inferred values.

### DIFF
--- a/internal/literals/literals.go
+++ b/internal/literals/literals.go
@@ -47,6 +47,11 @@ func Obfuscate(files []*ast.File, info *types.Info, fset *token.FileSet, ignoreO
 					return false
 				}
 
+				if len(spec.Values) == 0 {
+					// skip constants with inferred values
+					return false
+				}
+
 				for _, name := range spec.Names {
 					obj := info.ObjectOf(name)
 

--- a/testdata/scripts/literals.txt
+++ b/testdata/scripts/literals.txt
@@ -235,6 +235,13 @@ func stringTypeFunc(s stringType) stringType {
 	println(s)
 	return "stringType return" // skip
 }
+
+// obfuscating this broke before
+const (
+	iota0 uint8 = iota
+	iota1
+)
+
 -- main.stderr --
 Lorem true
 First Line


### PR DESCRIPTION
Obfuscating literals broke constants
with values inferred via iota before,
because they would be moved to a variable declaration instead.