### PR TITLE
Fix calls to linkname functions

### DIFF
--- a/main.go
+++ b/main.go
@@ -622,9 +622,15 @@ func transformCompile(args []string) ([]string, error) {
 	}
 
 	newPaths := make([]string, 0, len(files))
-	for i, file := range files {
-		tf.handleDirectives(file.Comments)
 
+	for _, file := range files {
+		// Process directives before obfuscating any names of the package,
+		// this is needed for functions which are linknamed to another package,
+		// but also used in the package declaring them.
+		tf.handleDirectives(file.Comments)
+	}
+
+	for i, file := range files {
 		origName := filepath.Base(paths[i])
 		name := origName
 		switch {

--- a/testdata/scripts/linkname.txt
+++ b/testdata/scripts/linkname.txt
@@ -16,6 +16,18 @@ cmp stderr main.stderr
 module test/main
 
 go 1.16
+
+-- a.go --
+package main
+
+// Call a function which is linknamed to another symbol.
+// What's special here is that we obfuscate this call before the function declaration.
+// If we decide not to obfuscate the name in the function declaration,
+// we shouldn't obfuscate the name here either.
+func linknameCalledInPkg() {
+	println(obfuscatedFunc())
+}
+
 -- main.go --
 package main
 
@@ -49,6 +61,7 @@ func main() {
 	println(obfuscatedFunc())
 	println(renamedFunc())
 	println(imported.ByteIndex("01234", '3'))
+	linknameCalledInPkg()
 }
 -- imported/imported.go --
 package imported
@@ -76,3 +89,4 @@ false
 obfuscated func
 renamed func
 3
+obfuscated func


### PR DESCRIPTION
I found this while poking at the runtime.

For example the time_now call can be obfuscated here:

https://go.googlesource.com/go/+/go1.16.2/src/runtime/mgc.go#1703

before finding this linkname directive along with the declaration in a separate file

https://go.googlesource.com/go/+/go1.16.2/src/runtime/timestub.go#14

This leads to the call being obfuscated and the function declaration being blacklisted later because of the linkname directive.
