### PR TITLE
testdata: use longer Go filenames for binsubstr

### DIFF
--- a/testdata/scripts/basic.txt
+++ b/testdata/scripts/basic.txt
@@ -1,5 +1,5 @@
 # Check that the simplest use of garble works. Note the lack of a module or GOPRIVATE.
-garble build main.go
+garble build -o=main$exe garble_main.go
 exec ./main
 cmp stderr main.stderr
 
@@ -23,25 +23,25 @@ stdout 'unknown'
 ! stdout $gofullversion
 
 # The binary can't contain the version string either.
-! binsubstr main$exe ${WORK@R} 'main.go' 'globalVar' 'globalFunc' 'garble' $gofullversion
+! binsubstr main$exe ${WORK@R} 'garble_main.go' 'globalVar' 'globalFunc' 'garble' $gofullversion
 
 [short] stop # checking that the build is reproducible is slow
 
 # Check that we fail if the user used "go build -toolexec garble" instead of "garble build"
-! go build -toolexec=garble main.go
+! go build -toolexec=garble -o=main$exe garble_main.go
 stderr 'not running "garble \[command\]"'
 
 # Also check that the binary is reproducible.
 # No packages should be rebuilt either, thanks to the build cache.
 cp main$exe main_old$exe
 rm main$exe
-garble build -v main.go
+garble build -v -o=main$exe garble_main.go
 ! stderr .
 bincmp main$exe main_old$exe
 
 # Check that the program works as expected without garble. No need to verify
 # this when we run with -short.
-go build main.go
+go build -o=main$exe garble_main.go
 exec ./main
 cmp stderr main.stderr
 
@@ -52,14 +52,14 @@ cmp stderr main.stderr
 
 # The default build includes full non-trimmed paths, as well as our names.
 # Only check $WORK on non-windows, because it's difficult to do it there.
-binsubstr main$exe 'main.go' 'globalVar' 'globalFunc' $gofullversion
+binsubstr main$exe 'garble_main.go' 'globalVar' 'globalFunc' $gofullversion
 [!windows] binsubstr main$exe ${WORK@R}
 
 -- go.mod --
 module test/mainfoo
 
 go 1.16
--- main.go --
+-- garble_main.go --
 package main
 
 var globalVar = "global value"

--- a/testdata/scripts/imports.txt
+++ b/testdata/scripts/imports.txt
@@ -20,7 +20,7 @@ garble build -tags buildtag
 exec ./main
 cmp stdout main.stdout
 
-! binsubstr main$exe 'ImportedVar' 'ImportedConst' 'ImportedFunc' 'main.go' 'test/main' 'importedpkg.' 'NormalStruct' 'normalUnexportedField'
+! binsubstr main$exe 'ImportedVar' 'ImportedConst' 'ImportedFunc' 'garble_main.go' 'test/main' 'importedpkg.' 'NormalStruct' 'normalUnexportedField'
 
 [short] stop # checking that the build is reproducible is slow
 
@@ -59,7 +59,7 @@ rsc.io/quote v1.5.2 h1:3fEykkD9k7lYzXqCYrwGAf7iNhbk4yCjHmKBN9td4L0=
 rsc.io/quote v1.5.2/go.mod h1:LzX7hefJvL54yjefDEDHNONDjII0t9xZLPXsUe+TKr0=
 rsc.io/sampler v1.3.0 h1:HLGR/BgEtI3r0uymSP/nl2uPLsUnNJX8toRyhfpBTII=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
--- main.go --
+-- garble_main.go --
 package main
 
 import (

--- a/testdata/scripts/position.txt
+++ b/testdata/scripts/position.txt
@@ -2,16 +2,16 @@ env GOPRIVATE=test/main
 
 garble build
 exec ./main
-! stdout 'someverylongmain\.go|other_file_name|is sorted'
+! stdout 'garble_main\.go|garble_other_filename|is sorted'
 
-! binsubstr main$exe 'someverylongmain.go' 'other_file_name'
+! binsubstr main$exe 'garble_main.go' 'garble_other_filename'
 
 [short] stop # no need to verify this with -short
 
 go build
 exec ./main
-stdout 'someverylongmain.go'
-stdout 'other_file_name'
+stdout 'garble_main.go'
+stdout 'garble_other_filename'
 stdout ':19: main'
 stdout 'initPositions is sorted'
 stdout 'varPositions is sorted'
@@ -20,7 +20,7 @@ stdout 'varPositions is sorted'
 module test/main
 
 go 1.16
--- someverylongmain.go --
+-- garble_main.go --
 package main
 
 import (
@@ -64,7 +64,7 @@ func main() {
 	// The nested expression is needed to prevent spaces.
 	fmt.Printf("%v\n", 10*float64(3.0)/float64(4.0))
 }
--- other_file_name.go --
+-- garble_other_filename.go --
 package main
 
 import (

--- a/testdata/scripts/reflect.txt
+++ b/testdata/scripts/reflect.txt
@@ -4,7 +4,7 @@ garble build
 exec ./main
 cmp stdout main.stdout
 
-! binsubstr main$exe 'main.go' 'test/main' 'importedpkg.' 'DownstreamObfuscated' 'SiblingObfuscated' 'IndirectObfuscated' 'IndirectNamedWithoutReflect' 'AliasIndirectNamedWithReflect' 'AliasIndirectNamedWithoutReflect'
+! binsubstr main$exe 'garble_main.go' 'test/main' 'importedpkg.' 'DownstreamObfuscated' 'SiblingObfuscated' 'IndirectObfuscated' 'IndirectNamedWithoutReflect' 'AliasIndirectNamedWithReflect' 'AliasIndirectNamedWithoutReflect'
 binsubstr main$exe 'ReflectInDefined' 'ExportedField2' 'unexportedField2' 'IndirectUnobfuscated' 'IndirectNamedWithReflect'
 
 [short] stop # no need to verify this with -short
@@ -18,7 +18,7 @@ cmp stdout main.stdout
 module test/main
 
 go 1.16
--- main.go --
+-- garble_main.go --
 package main
 
 import (

--- a/testdata/scripts/tiny.txt
+++ b/testdata/scripts/tiny.txt
@@ -2,7 +2,7 @@ env GOPRIVATE=test/main
 
 # Tiny mode
 garble -tiny build
-! binsubstr main$exe 'main.go' 'fmt/print.go'
+! binsubstr main$exe 'garble_main.go' 'fmt/print.go'
 env GODEBUG='allocfreetrace=1,gcpacertrace=1,gctrace=1,inittrace=1,scavenge=1,scavtrace=1,scheddetail=1,schedtrace=10'
 ! exec ./main$exe
 stderr '^\(0x[\d\w]{4,8},0x[\d\w]{4,8}\)' # interfaces/pointers print correctly
@@ -29,7 +29,7 @@ stderr 'panic: oh noes'
 module test/main
 
 go 1.16
--- main.go --
+-- garble_main.go --
 package main
 
 import "runtime"


### PR DESCRIPTION
(see commit message)