### PR TITLE
fix runtime stripping for Go 1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
         go test ./...
 
   test-gotip:
+    if: ${{ false }} # TODO: support Go 1.18, see https://github.com/burrowers/garble/issues/385
     runs-on: ubuntu-latest
     continue-on-error: true # master breaks sometimes
     steps:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/google/go-cmp v0.5.6
-	github.com/rogpeppe/go-internal v1.8.0
+	github.com/rogpeppe/go-internal v1.8.1-0.20211023094830-115ce09fd6b4
 	golang.org/x/mod v0.5.0
 	golang.org/x/tools v0.1.5
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e h1:aoZm08cpOy4WuID//EZDgc
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+github.com/rogpeppe/go-internal v1.8.1-0.20211023094830-115ce09fd6b4 h1:Ha8xCaq6ln1a+R91Km45Oq6lPXj2Mla6CRJYcuV2h1w=
+github.com/rogpeppe/go-internal v1.8.1-0.20211023094830-115ce09fd6b4/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/runtime_strip.go
+++ b/runtime_strip.go
@@ -128,7 +128,8 @@ func stripRuntime(filename string, file *ast.File) {
 			switch filename {
 			case "print.go":
 				// was used in hexdumpWords
-				x.Specs = removeImport(`"runtime/internal/sys"`, x.Specs)
+				x.Specs = removeImport(`"runtime/internal/sys"`, x.Specs) // Before Go 1.18.
+				x.Specs = removeImport(`"internal/goarch"`, x.Specs)      // Go 1.18.
 			case "traceback.go":
 				// was used in traceback1
 				x.Specs = removeImport(`"runtime/internal/atomic"`, x.Specs)


### PR DESCRIPTION
In Go 1.18 runtime/internal/sys is replaced with internal/goarch. This change makes sure that when running garble after the runtime package change, runtime stripping correctly removes the unused import.

Prior to this change, running garble with -tiny on Go tip (golang/go@61d789db3a52e4570596f1fd15122358deb73b77) results in the following failure:
```
# runtime
/tmp/garble-shared3879740160/runtime/print.go:8:2: imported and not used: "internal/goarch"
exit status 2
exit status 2
```

Please take a look.