### PR TITLE
testdata: adjust for newer Go 1.18 tip version

### DIFF
--- a/testdata/scripts/modinfo.txt
+++ b/testdata/scripts/modinfo.txt
@@ -24,8 +24,8 @@ go build -tags veryuniquebuildtag
 go version -m main$exe
 stdout 'path\s*test/main'
 stdout 'mod\s*test/main\s*\(devel\)'
-[go1.18] stdout 'build\s*tags.*veryuniquebuildtag'
-[go1.18] stdout 'build\s*gitrevision.*'${HEAD_COMMIT_SHA}
+[go1.18] stdout 'build\s*-tags=veryuniquebuildtag'
+[go1.18] stdout 'build\s*vcs.revision='${HEAD_COMMIT_SHA}
 
 -- go.mod --
 module test/main


### PR DESCRIPTION
(see commit message)

