### PR TITLE
testdata: ensure go:noinline works via runtime.Callers

### DIFF
--- a/testdata/scripts/reverse.txt
+++ b/testdata/scripts/reverse.txt
@@ -90,7 +90,9 @@ import (
 	"runtime/debug"
 )
 
-type ExportedLibType struct{}
+type ExportedLibType struct{
+	ExportedLibField int
+}
 
 func (*ExportedLibType) ExportedLibMethod(w io.Writer) error {
 	_, filename, _, _ := runtime.Caller(0)
@@ -142,9 +144,9 @@ goroutine 1 [running]:
 runtime/debug.Stack(...)
 	runtime/debug/stack.go:24 +0x??
 test/main/lib.printStackTrace(...)
-	test/main/lib/lib.go:30 +0x??
+	test/main/lib/lib.go:32 +0x??
 test/main/lib.(*ExportedLibType).ExportedLibMethod(...)
-	test/main/lib/lib.go:17 +0x??
+	test/main/lib/lib.go:19 +0x??
 main.unexportedMainFunc.func1(...)
 	test/main/main.go:21
 main.unexportedMainFunc(...)

--- a/testdata/scripts/syntax.txt
+++ b/testdata/scripts/syntax.txt
@@ -41,6 +41,7 @@ package main
 
 import (
 	"go/ast"
+	"runtime"
 
 	"private.source/extra"
 	"test/main/sub"
@@ -75,9 +76,36 @@ type EmbeddingUniverseScope struct {
 
 // TODO: test that go:noinline still works without using debugdir
 
+func ensureInlined(wantInlined bool) {
+	pc := make([]uintptr, 1)
+	// We skip two caller frames; runtime.Callers, and ensureInlined.
+	// This way, the frame we get is our caller, like neverInlined.
+	n := runtime.Callers(2, pc)
+	if n == 0 {
+		panic("got zero callers?")
+	}
+	pc = pc[:n]
+
+	frames := runtime.CallersFrames(pc)
+
+	frame, _ := frames.Next()
+	gotInlined := frame.Func == nil
+	if wantInlined && !gotInlined {
+		panic("caller should be inlined but wasn't")
+	} else if !wantInlined && gotInlined {
+		panic("caller shouldn't be inlined but was")
+	}
+}
+
 //go:noinline
 func neverInlined() {
+	ensureInlined(false)
 	println("This func is never inlined.")
+}
+
+func alwaysInlined() {
+	ensureInlined(true)
+	println("This func is always inlined.")
 }
 
 type EmbeddingOuter struct {
@@ -100,6 +128,7 @@ func main() {
 	println(extra.Func())
 	sub.Test()
 	neverInlined()
+	alwaysInlined()
 
 	_ = sub.EmbeddingExternalForeignAlias{
 		ExternalForeignAlias: nil,
@@ -228,3 +257,4 @@ nil case
 1 4 5 1 input
 This is a separate module to obfuscate.
 This func is never inlined.
+This func is always inlined.


### PR DESCRIPTION
(see commit message)

