### PR TITLE
remove 3% of allocs in garble

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,6 +210,14 @@ func debugSince(start time.Time) time.Duration {
 }
 
 func main1() int {
+	defer func() {
+		if os.Getenv("GARBLE_WRITE_ALLOCS") != "true" {
+			return
+		}
+		var memStats runtime.MemStats
+		runtime.ReadMemStats(&memStats)
+		fmt.Fprintf(os.Stderr, "garble allocs: %d\n", memStats.Mallocs)
+	}()
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		return 2
 	}


### PR DESCRIPTION
(see commit messages - please do not squash)

The overhead of the GC in the benchmark build is just a few percent, so 3% of that is negligible and doesn't really show up in the time/op numbers. Still, every bit helps.