### PR TITLE
Disable seed obfuscator

### DIFF
--- a/internal/literals/obfuscators.go
+++ b/internal/literals/obfuscators.go
@@ -21,7 +21,7 @@ var obfuscators = []obfuscator{
 	swap{},
 	split{},
 	shuffle{},
-	seed{},
+	// seed{}, TODO: re-enable once https://github.com/golang/go/issues/47631 is fixed
 }
 
 // If math/rand.Seed() is not called, the generator behaves as if seeded by rand.Seed(1),

--- a/testdata/scripts/literals.txt
+++ b/testdata/scripts/literals.txt
@@ -46,8 +46,9 @@ grep '^\s+\w+ \^= \w+ \* \w+$' debug1/test/main/extra_literals.go
 # Note that the line obfuscator adds an inline comment before the call.
 grep '^\s+\w+ = .*\bappend\(\w+,(\s+\w+\[\d+\][\^\-+]\w+\[\d+\],?)+\)$' debug1/test/main/extra_literals.go
 
+# TODO: re-enable once https://github.com/golang/go/issues/47631 is fixed
 # XorSeed obfuscator. Detect type decFunc func(byte) decFunc
-grep '^\s+type \w+ func\(byte\) \w+$' debug1/test/main/extra_literals.go
+# grep '^\s+type \w+ func\(byte\) \w+$' debug1/test/main/extra_literals.go 
 
 # Finally, sanity check that we can build all of std with -literals.
 # Analogous to gogarble.txt.


### PR DESCRIPTION
The seed obfuscator uses a type declaration in order to declare a function,
which returns a function with the same type.

This breaks when obfuscating literals inside generic functions, because
type declarations inside generic functions are not currently supported.

Therefore the obfuscator gets disabled until
https://github.com/golang/go/issues/47631 is fixed.