### PR TITLE
avoid go/printer from breaking imports

### DIFF
--- a/main.go
+++ b/main.go
@@ -1740,7 +1740,10 @@ func (tf *transformer) transformGo(file *ast.File) *ast.File {
 		newPath := lpkg.obfuscatedImportPath()
 		imp.Path.Value = strconv.Quote(newPath)
 		if imp.Name == nil {
-			imp.Name = &ast.Ident{Name: lpkg.Name}
+			imp.Name = &ast.Ident{
+				NamePos: imp.Path.ValuePos, // ensure it ends up on the same line
+				Name:    lpkg.Name,
+			}
 		}
 		return true
 	}

--- a/testdata/scripts/imports.txt
+++ b/testdata/scripts/imports.txt
@@ -151,6 +151,34 @@ type NormalStruct struct {
 	normalUnexportedField int
 }
 
+-- importedpkg/commented_imports.go --
+package importedpkg
+
+// The import group below used to trigger a bug in go/printer
+// where a named import could end up across two lines:
+//
+//   indirect
+//   "HPS4Mskq"
+//
+// resulting in a subsequent parsing failure:
+//
+//   syntax error: missing import path
+
+import (
+	// first comment
+
+	"test/main/importedpkg/another"
+
+	// second comment
+	"test/main/importedpkg/indirect"
+)
+
+var _ indirect.Indirect
+var _ = another.Blank
+-- importedpkg/another/pkg.go --
+package another
+
+const Blank = 3
 -- importedpkg/indirect/indirect.go --
 package indirect
 


### PR DESCRIPTION
(see commit message)

