### PR TITLE
fix `garble reverse` on packages using cgo or assembly

### DIFF
--- a/reverse.go
+++ b/reverse.go
@@ -89,7 +89,7 @@ One can reverse a captured panic stack trace as follows:
 			}
 			file, err := parser.ParseFile(fset, goFile, nil, parser.SkipObjectResolution)
 			if err != nil {
-				return err
+				return fmt.Errorf("go parse: %w", err)
 			}
 			files = append(files, file)
 		}

--- a/shared.go
+++ b/shared.go
@@ -140,10 +140,10 @@ type listedPackage struct {
 	ImportMap  map[string]string
 	Standard   bool
 
-	Dir        string
-	GoFiles    []string
-	Imports    []string
-	Incomplete bool
+	Dir             string
+	CompiledGoFiles []string
+	Imports         []string
+	Incomplete      bool
 
 	// The fields below are not part of 'go list', but are still reused
 	// between garble processes. Use "Garble" as a prefix to ensure no
@@ -180,7 +180,7 @@ func appendListedPackages(packages []string, withDeps bool) error {
 	// TODO: perhaps include all top-level build flags set by garble,
 	// including -buildvcs=false.
 	// They shouldn't affect "go list" here, but might as well be consistent.
-	args := []string{"list", "-json", "-export", "-trimpath", "-e"}
+	args := []string{"list", "-json", "-export", "-compiled", "-trimpath", "-e"}
 	if withDeps {
 		args = append(args, "-deps")
 	}

--- a/testdata/script/asm.txtar
+++ b/testdata/script/asm.txtar
@@ -13,6 +13,12 @@ cmp stderr main.stderr
 
 [short] stop # no need to verify this with -short
 
+# Ensure that reversing doesn't error with assembly files.
+# It should fail, as there is nothing to reverse, but without any parse error.
+stdin empty-reverse.txt
+! garble reverse .
+! stderr .
+
 garble -tiny build
 exec ./main
 cmp stderr main.stderr
@@ -101,3 +107,4 @@ TEXT ·PublicAdd(SB),$0-16
 13 36
 25 70
 7
+-- empty-reverse.txt --

--- a/testdata/script/cgo.txtar
+++ b/testdata/script/cgo.txtar
@@ -10,6 +10,15 @@ cmp stdout main.stdout
 
 [short] stop # no need to verify this with -short
 
+# Ensure that reversing works with cgo.
+env GARBLE_TEST_REVERSING=true
+exec ./main
+cp stdout reversing.stdout
+stdin reversing.stdout
+garble reverse .
+cmp stdout reversed.stdout
+env GARBLE_TEST_REVERSING=false
+
 env GOGARBLE=*
 garble build
 exec ./main
@@ -33,7 +42,34 @@ go 1.18
 -- main.go --
 package main
 
-import "os/user"
+func main() {
+	regularFunc()
+	cgoFunc()
+}
+-- regular_main.go --
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+func regularFunc() {
+	if os.Getenv("GARBLE_TEST_REVERSING") == "true" {
+		_, filename, _, _ := runtime.Caller(0)
+		fmt.Println("regular filename:", filename)
+	}
+}
+-- cgo_main.go --
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"runtime"
+)
 
 /*
 #include "separate.h"
@@ -54,9 +90,8 @@ struct portedStruct {
 };
 */
 import "C"
-import "fmt"
 
-func main() {
+func cgoFunc() {
 	fmt.Println(C.privateAdd(C.int(1), C.int(2)))
 	_, _ = user.Current()
 
@@ -69,6 +104,11 @@ func main() {
 //export goCallback
 func goCallback() {
 	fmt.Println("go callback")
+	// TODO: support reversing filenames in cgo files
+	if false && os.Getenv("GARBLE_TEST_REVERSING") == "true" {
+		_, filename, _, _ := runtime.Caller(0)
+		fmt.Println("cgo filename:", filename)
+	}
 }
 -- separate.h --
 void separateFunction();
@@ -79,6 +119,12 @@ void separateFunction() {
 	goCallback();
 }
 -- main.stdout --
+3
+true
+go callback
+go callback
+-- reversed.stdout --
+regular filename: test/main/regular_main.go
 3
 true
 go callback


### PR DESCRIPTION
(see commit messages - please do not squash)

Fixes #555.