### PR TITLE
CI: stop tracking macos-latest for now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,8 @@ jobs:
     strategy:
       matrix:
         go-version: [1.19.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # TODO: revert to macos-latest once we figure out https://github.com/burrowers/garble/issues/609.
+        os: [ubuntu-latest, macos-11, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/setup-go@v3


### PR DESCRIPTION
(see commit message)

For #609.