### PR TITLE
README: drop obsolete note about `//export` declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,6 @@ to document the current shortcomings of this tool.
    var _ = reflect.TypeOf(Message{})
    ```
 
-* Go declarations exported for cgo via `//export` are not obfuscated.
-
 * Go plugins are not currently supported; see [#87](https://github.com/burrowers/garble/issues/87).
 
 ### Contributing


### PR DESCRIPTION
(see commit message)

