### PR TITLE
add entryoff encryption

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -211,7 +211,7 @@ func magicValue() uint32 {
 // entryOffKey returns random entry offset key
 // on user specified seed or the runtime package's GarbleActionID.
 func entryOffKey() uint32 {
-	return 1 + runtimeHashWithCustomSalt([]byte("entryOffKey"))
+	return runtimeHashWithCustomSalt([]byte("entryOffKey"))
 }
 
 func hashWithPackage(pkg *listedPackage, name string) string {

--- a/hash.go
+++ b/hash.go
@@ -211,7 +211,7 @@ func magicValue() uint32 {
 // entryOffKey returns random entry offset key
 // on user specified seed or the runtime package's GarbleActionID.
 func entryOffKey() uint32 {
-	return runtimeHashWithCustomSalt([]byte("entryOffKey"))
+	return 1 + runtimeHashWithCustomSalt([]byte("entryOffKey"))
 }
 
 func hashWithPackage(pkg *listedPackage, name string) string {

--- a/hash.go
+++ b/hash.go
@@ -190,17 +190,28 @@ func isUpper(b byte) bool { return 'A' <= b && b <= 'Z' }
 func toLower(b byte) byte { return b + ('a' - 'A') }
 func toUpper(b byte) byte { return b - ('a' - 'A') }
 
-// magicValue returns random magic value based
-// on user specified seed or the runtime package's GarbleActionID.
-func magicValue() uint32 {
+func runtimeHashWithCustomSalt(salt []byte) uint32 {
 	hasher.Reset()
 	if !flagSeed.present() {
 		hasher.Write(cache.ListedPackages["runtime"].GarbleActionID)
 	} else {
 		hasher.Write(flagSeed.bytes)
 	}
+	hasher.Write(salt)
 	sum := hasher.Sum(sumBuffer[:0])
 	return binary.LittleEndian.Uint32(sum)
+}
+
+// magicValue returns random magic value based
+// on user specified seed or the runtime package's GarbleActionID.
+func magicValue() uint32 {
+	return runtimeHashWithCustomSalt([]byte("magic"))
+}
+
+// entryOffKey returns random entry offset key
+// on user specified seed or the runtime package's GarbleActionID.
+func entryOffKey() uint32 {
+	return runtimeHashWithCustomSalt([]byte("entryOffKey"))
 }
 
 func hashWithPackage(pkg *listedPackage, name string) string {

--- a/internal/linker/linker.go
+++ b/internal/linker/linker.go
@@ -22,8 +22,9 @@ import (
 )
 
 const (
-	MagicValueEnv = "GARBLE_LINK_MAGIC"
-	TinyEnv       = "GARBLE_LINK_TINY"
+	MagicValueEnv  = "GARBLE_LINK_MAGIC"
+	TinyEnv        = "GARBLE_LINK_TINY"
+	EntryOffKeyEnv = "GARBLE_LINK_ENTRYOFF_KEY"
 
 	cacheDirName   = "garble"
 	versionExt     = ".version"

--- a/internal/linker/patches/0003-add-entryOff-encryption.patch
+++ b/internal/linker/patches/0003-add-entryOff-encryption.patch
@@ -1,17 +1,17 @@
-From a9c0b26ab88f04509991b10d007f1d885c87fed4 Mon Sep 17 00:00:00 2001
+From 99349f6e00859e1bd5c1dd14921b6b9d4aac9966 Mon Sep 17 00:00:00 2001
 From: pagran <pagran@protonmail.com>
-Date: Tue, 10 Jan 2023 23:56:45 +0100
+Date: Sat, 14 Jan 2023 21:36:16 +0100
 Subject: [PATCH 3/3] add entryOff encryption
 
 ---
- cmd/link/internal/ld/pcln.go | 18 ++++++++++++++++++
- 1 file changed, 18 insertions(+)
+ cmd/link/internal/ld/pcln.go | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
 
 diff --git a/cmd/link/internal/ld/pcln.go b/cmd/link/internal/ld/pcln.go
-index ab13b15042..48e656cf89 100644
+index ab13b15042..8e2fa09434 100644
 --- a/cmd/link/internal/ld/pcln.go
 +++ b/cmd/link/internal/ld/pcln.go
-@@ -790,6 +790,24 @@ func writeFuncs(ctxt *Link, sb *loader.SymbolBuilder, funcs []loader.Sym, inlSym
+@@ -790,6 +790,26 @@ func writeFuncs(ctxt *Link, sb *loader.SymbolBuilder, funcs []loader.Sym, inlSym
  			sb.SetUint32(ctxt.Arch, dataoff, uint32(ldr.SymValue(fdsym)-gofuncBase))
  		}
  	}
@@ -31,7 +31,9 @@ index ab13b15042..48e656cf89 100644
 +	garbleData := sb.Data()
 +	for _, off := range startLocations {
 +		entryOff := ctxt.Arch.ByteOrder.Uint32(garbleData[off:])
-+		sb.SetUint32(ctxt.Arch, int64(off), entryOff^garbleEntryOffKey)
++		nameOff := ctxt.Arch.ByteOrder.Uint32(garbleData[off+4:])
++
++		sb.SetUint32(ctxt.Arch, int64(off), entryOff^(nameOff*garbleEntryOffKey))
 +	}
  }
  

--- a/internal/linker/patches/0003-add-entryOff-encryption.patch
+++ b/internal/linker/patches/0003-add-entryOff-encryption.patch
@@ -1,0 +1,41 @@
+From a9c0b26ab88f04509991b10d007f1d885c87fed4 Mon Sep 17 00:00:00 2001
+From: pagran <pagran@protonmail.com>
+Date: Tue, 10 Jan 2023 23:56:45 +0100
+Subject: [PATCH 3/3] add entryOff encryption
+
+---
+ cmd/link/internal/ld/pcln.go | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/cmd/link/internal/ld/pcln.go b/cmd/link/internal/ld/pcln.go
+index ab13b15042..48e656cf89 100644
+--- a/cmd/link/internal/ld/pcln.go
++++ b/cmd/link/internal/ld/pcln.go
+@@ -790,6 +790,24 @@ func writeFuncs(ctxt *Link, sb *loader.SymbolBuilder, funcs []loader.Sym, inlSym
+ 			sb.SetUint32(ctxt.Arch, dataoff, uint32(ldr.SymValue(fdsym)-gofuncBase))
+ 		}
+ 	}
++
++	// Moving next code higher is not recommended.
++	// Only at the end of the current function no edits between go versions
++	garbleEntryOffKeyStr := os.Getenv("GARBLE_LINK_ENTRYOFF_KEY")
++	if garbleEntryOffKeyStr == "" {
++		panic("[garble] entryOff key must be set")
++	}
++	var garbleEntryOffKey uint32
++	// Use fmt package instead of strconv to avoid importing a new package
++	if _, err := fmt.Sscan(garbleEntryOffKeyStr, &garbleEntryOffKey); err != nil {
++		panic(fmt.Errorf("[garble] invalid entryOff key %s: %v", garbleEntryOffKeyStr, err))
++	}
++
++	garbleData := sb.Data()
++	for _, off := range startLocations {
++		entryOff := ctxt.Arch.ByteOrder.Uint32(garbleData[off:])
++		sb.SetUint32(ctxt.Arch, int64(off), entryOff^garbleEntryOffKey)
++	}
+ }
+ 
+ // pclntab initializes the pclntab symbol with
+-- 
+2.38.1.windows.1
+

--- a/main.go
+++ b/main.go
@@ -449,6 +449,7 @@ func mainErr(args []string) error {
 
 			executablePath = modifiedLinkPath
 			os.Setenv(linker.MagicValueEnv, strconv.FormatUint(uint64(magicValue()), 10))
+			os.Setenv(linker.EntryOffKeyEnv, strconv.FormatUint(uint64(entryOffKey()), 10))
 			if flagTiny {
 				os.Setenv(linker.TinyEnv, "true")
 			}
@@ -930,6 +931,7 @@ func transformCompile(args []string) ([]string, error) {
 			}
 			if basename == "symtab.go" {
 				updateMagicValue(file, magicValue())
+				updateEntryOffset(file, entryOffKey())
 			}
 		}
 		tf.handleDirectives(file.Comments)

--- a/runtime_patch.go
+++ b/runtime_patch.go
@@ -71,6 +71,7 @@ func updateEntryOffset(file *ast.File, entryOffKey uint32) {
 
 	// The funcInfo.nameoff field can be renamed between versions and for more stability
 	// we dynamically extract its name from the cfuncname function.
+	// Note that extractNameOff must be called before updateEntryOff.
 	extractNameOff := func(node ast.Node) bool {
 		indexExpr, ok := node.(*ast.IndexExpr)
 		if !ok {


### PR DESCRIPTION
Added a simple encryption with a random key for `funcInfo.entryoff`, this completely breaks function info parsing since it breaks link `_func->offset in binary`


There is a problem that encrypted addresses look sequential:
```
Create function @ 0x4815c0 // invalid address
Create function @ 0x481880
Create function @ 0x481b40
Create function @ 0x481bc0
Create function @ 0x481f20
Create function @ 0x4824c0
```

If you know, please write how to encrypt (with a simple algorithm), to make a resulting number look more random