### PR TITLE
preallocate data in shuffle and split literal obfuscator

### DIFF
--- a/internal/literals/shuffle.go
+++ b/internal/literals/shuffle.go
@@ -52,14 +52,10 @@ func (shuffle) obfuscate(obfRand *mathrand.Rand, data []byte) *ast.BlockStmt {
 			Tok: token.DEFINE,
 			Rhs: []ast.Expr{ah.DataToByteSlice(shuffledFullData)},
 		},
-		&ast.DeclStmt{
-			Decl: &ast.GenDecl{
-				Tok: token.VAR,
-				Specs: []ast.Spec{&ast.ValueSpec{
-					Names: []*ast.Ident{ast.NewIdent("data")},
-					Type:  &ast.ArrayType{Elt: ast.NewIdent("byte")},
-				}},
-			},
+		&ast.AssignStmt{
+			Lhs: []ast.Expr{ast.NewIdent("data")},
+			Tok: token.DEFINE,
+			Rhs: []ast.Expr{ah.CallExpr(ast.NewIdent("make"), &ast.ArrayType{Elt: ast.NewIdent("byte")}, ah.IntLit(0), ah.IntLit(len(data)+1))},
 		},
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("data")},

--- a/internal/literals/split.go
+++ b/internal/literals/split.go
@@ -158,15 +158,11 @@ func (split) obfuscate(obfRand *mathrand.Rand, data []byte) *ast.BlockStmt {
 	}
 
 	return ah.BlockStmt(
-		&ast.DeclStmt{Decl: &ast.GenDecl{
-			Tok: token.VAR,
-			Specs: []ast.Spec{
-				&ast.ValueSpec{
-					Names: []*ast.Ident{ast.NewIdent("data")},
-					Type:  &ast.ArrayType{Elt: ast.NewIdent("byte")},
-				},
-			},
-		}},
+		&ast.AssignStmt{
+			Lhs: []ast.Expr{ast.NewIdent("data")},
+			Tok: token.DEFINE,
+			Rhs: []ast.Expr{ah.CallExpr(ast.NewIdent("make"), &ast.ArrayType{Elt: ast.NewIdent("byte")}, ah.IntLit(0), ah.IntLit(len(data)+1))},
+		},
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("i")},
 			Tok: token.DEFINE,


### PR DESCRIPTION
Synthetic [test](https://gist.github.com/pagran/bbe5e7b2680dd02689064a634d2588a3) results demonstrate 30%+ speedup:
```
Before: 502700 ns/op
After: 303700 ns/op
```