### PR TITLE
Add support for obfuscation of dot-imported string constants

### DIFF
--- a/main.go
+++ b/main.go
@@ -1691,7 +1691,7 @@ func (tf *transformer) removeUnnecessaryImports(file *ast.File) {
 			return true
 		}
 
-		uses, ok := tf.info.Uses[node].(types.Object)
+		uses, ok := tf.info.Uses[node]
 		if !ok {
 			return true
 		}

--- a/main.go
+++ b/main.go
@@ -1691,18 +1691,20 @@ func (tf *transformer) removeUnnecessaryImports(file *ast.File) {
 			return true
 		}
 
-		uses, ok := tf.info.Uses[node].(*types.PkgName)
+		uses, ok := tf.info.Uses[node].(types.Object)
 		if !ok {
 			return true
 		}
 
-		usedImports[uses.Imported().Path()] = true
+		if pkg := uses.Pkg(); pkg != nil {
+			usedImports[pkg.Path()] = true
+		}
 
 		return true
 	})
 
 	for _, imp := range file.Imports {
-		if imp.Name != nil && (imp.Name.Name == "_" || imp.Name.Name == ".") {
+		if imp.Name != nil && imp.Name.Name == "_" {
 			continue
 		}
 

--- a/testdata/script/literals.txtar
+++ b/testdata/script/literals.txtar
@@ -62,6 +62,10 @@ import (
 	_ "runtime/debug"
 
 	"test/main/imp"
+	. "test/main/imp_const"
+	. "test/main/imp_func"
+	. "test/main/imp_var"
+	. "test/main/imp_type"
 )
 
 type structTest struct {
@@ -140,6 +144,7 @@ func main() {
 	constantTest()
 	byteTest()
 	shadowTest()
+	dotImportTest()
 
 	strArray := [2]string{"1: literal in", "an secret array"}
 	println(strArray[0], strArray[1])
@@ -319,10 +324,39 @@ func shadowTest() {
 		println("obfuscated with shadowed builtins (types)")
 	}
 }
+
+func dotImportTest() {
+    println(DotImportedStr)
+    println(DotImportedFunc())
+    println(DotImportedVar)
+    println(DotImportedType("str as dot imported type"))
+}
 -- imp/imported.go --
 package imported
 
 type ImportedType int
+-- imp_const/imported.go --
+package imp_const
+
+const DotImportedStr = "const str from dot imported var"
+
+-- imp_func/imported.go --
+package imp_func
+
+func DotImportedFunc() string {
+	return "str from dot imported func"
+}
+
+-- imp_var/imported.go --
+package imp_var
+
+var DotImportedVar = "str from dot imported var"
+
+-- imp_type/imported.go --
+package imp_type
+
+type DotImportedType string
+
 -- directives.go --
 // If we misplace any of the directives below,
 // cmd/compile will complain with "misplaced compiler directive".
@@ -407,5 +441,9 @@ chungus!!
 99,104,117,110,103,117,115,117,115,
 obfuscated with shadowed builtins (vars)
 obfuscated with shadowed builtins (types)
+const str from dot imported var
+str from dot imported func
+str from dot imported var
+str as dot imported type
 1: literal in an secret array
 2: literal in a secret slice


### PR DESCRIPTION
Implemented by additional analysis of all `*ast.Ident` of type `types.Object` (funcs, vars, types)

Fix #651 
Fix #610