### PR TITLE
CHANGELOG: prepare for v0.9.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v0.9.1] - 2023-01-26
+
+This bugfix release continues support for Go 1.19 and the upcoming Go 1.20,
+and features:
+
+* Support obfuscating code which uses "dot imports" - [#610]
+* Fix linking errors for MIPS architectures - [#646]
+* Compiler intrinsics for packages like `math/bits` work again - [#655]
+
 ## [v0.9.0] - 2023-01-17
 
 This release continues support for Go 1.19 and the upcoming Go 1.20.
@@ -175,6 +184,11 @@ Known bugs:
 
 * obfuscating the standard library with `GOPRIVATE=*` is not well supported yet
 * `garble test` is temporarily disabled, as it is currently broken
+
+[v0.9.1]: https://github.com/burrowers/garble/releases/tag/v0.9.1
+[#610]: https://github.com/burrowers/garble/issues/610
+[#646]: https://github.com/burrowers/garble/issues/646
+[#655]: https://github.com/burrowers/garble/pull/655
 
 [v0.9.0]: https://github.com/burrowers/garble/releases/tag/v0.9.0
 [#619]: https://github.com/burrowers/garble/issues/619


### PR DESCRIPTION
(see commit message)

