### PR TITLE
fix git apply and go build current directory

### DIFF
--- a/internal/linker/linker.go
+++ b/internal/linker/linker.go
@@ -119,7 +119,8 @@ func applyPatches(srcDir, workingDir string, modFiles map[string]bool, patches [
 		}
 	}
 
-	cmd := exec.Command("git", "-C", workingDir, "apply")
+	cmd := exec.Command("git", "apply")
+	cmd.Dir = workingDir
 	cmd.Stdin = bytes.NewReader(bytes.Join(patches, []byte("\n")))
 	if err := cmd.Run(); err != nil {
 		return nil, err
@@ -187,6 +188,8 @@ func buildLinker(workingDir string, overlay map[string]string, outputLinkPath st
 	cmd := exec.Command("go", "build", "-overlay", overlayPath, "-o", outputLinkPath, "cmd/link")
 	// Explicitly setting GOOS and GOARCH variables prevents conflicts during cross-build
 	cmd.Env = append(os.Environ(), "GOOS="+runtime.GOOS, "GOARCH="+runtime.GOARCH)
+	// Building cmd/link is possible from anywhere, but to avoid any possible side effects build in a temp directory
+	cmd.Dir = workingDir
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Change git apply invocation, use of `-C` flag to change current folder is not safe. 
If `garble` runs in directory containing a git repository, it can trigger dangerous side-effects and cause hard-to-reproduce errors.
Also due same reasons current folder for linker build is set to a temporary folder.