### PR TITLE
support inline and non-spaced comments in assembly

### DIFF
--- a/main.go
+++ b/main.go
@@ -698,14 +698,15 @@ func transformAsm(args []string) ([]string, error) {
 			}
 
 			// Leave "//" comments unchanged; they might be directives.
-			if strings.HasPrefix(strings.TrimSpace(line), "// ") {
-				buf.WriteString(line)
-				buf.WriteByte('\n')
-				continue
-			}
+			line, comment, hasComment := strings.Cut(line, "//")
 
 			// Anything else is regular assembly; replace the names.
 			replaceAsmNames(&buf, []byte(line))
+
+			if hasComment {
+				buf.WriteString("//")
+				buf.WriteString(comment)
+			}
 			buf.WriteByte('\n')
 		}
 		if err := scanner.Err(); err != nil {

--- a/testdata/script/asm.txtar
+++ b/testdata/script/asm.txtar
@@ -68,8 +68,9 @@ func main() {
 #include "extra/garble_define2_amd64.h"
 
 // A comment may include many·special∕asm·runes and it's okay.
-// Or the same with leading whitespace:
-	// A comment may include many·special∕asm·runes and it's okay.
+//No space: many·special∕asm·runes.
+	// Indented: many·special∕asm·runes.
+DATA bar+0(SB)/8, $0 // Inline: many·special∕asm·runes.
 
 // Reference an imported package by its package path.
 TEXT ·addJmpPkgPath(SB),$0-16


### PR DESCRIPTION
(see commit message)

Fixes #672.