### PR TITLE
disable repository search in parent directories

### DIFF
--- a/internal/linker/linker.go
+++ b/internal/linker/linker.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 
 	"github.com/bluekeyes/go-gitdiff/gitdiff"
@@ -119,11 +120,21 @@ func applyPatches(srcDir, workingDir string, modFiles map[string]bool, patches [
 		}
 	}
 
-	cmd := exec.Command("git", "--git-dir", workingDir, "apply")
+	// If one of parent folders of workingDir contains repository, set current directory is not enough because git
+	// by default treats workingDir as a subfolder of repository, so it will break git apply. Adding --git-dir flag blocks this behavior.
+	cmd := exec.Command("git", "--git-dir", workingDir, "apply", "--verbose")
 	cmd.Dir = workingDir
 	cmd.Stdin = bytes.NewReader(bytes.Join(patches, []byte("\n")))
-	if err := cmd.Run(); err != nil {
+	out, err := cmd.CombinedOutput()
+	if err != nil {
 		return nil, err
+	}
+
+	// Running git without errors does not guarantee that all patches have been applied.
+	// Make sure that all passed patches have been applied correctly.
+	reg := regexp.MustCompile(`(?m)^Applied patch .+ cleanly\.$`)
+	if appliedPatches := len(reg.FindAllIndex(out, -1)); appliedPatches != len(patches) {
+		return nil, fmt.Errorf("expected %d applied patches, actually %d:\n\n%s", len(patches), appliedPatches, string(out))
 	}
 	return mod, nil
 }

--- a/internal/linker/linker.go
+++ b/internal/linker/linker.go
@@ -119,7 +119,7 @@ func applyPatches(srcDir, workingDir string, modFiles map[string]bool, patches [
 		}
 	}
 
-	cmd := exec.Command("git", "apply")
+	cmd := exec.Command("git", "--git-dir", workingDir, "apply")
 	cmd.Dir = workingDir
 	cmd.Stdin = bytes.NewReader(bytes.Join(patches, []byte("\n")))
 	if err := cmd.Run(); err != nil {

--- a/internal/linker/linker.go
+++ b/internal/linker/linker.go
@@ -132,8 +132,8 @@ func applyPatches(srcDir, workingDir string, modFiles map[string]bool, patches [
 
 	// Running git without errors does not guarantee that all patches have been applied.
 	// Make sure that all passed patches have been applied correctly.
-	reg := regexp.MustCompile(`(?m)^Applied patch .+ cleanly\.$`)
-	if appliedPatches := len(reg.FindAllIndex(out, -1)); appliedPatches != len(patches) {
+	rx := regexp.MustCompile(`(?m)^Applied patch .+ cleanly\.$`)
+	if appliedPatches := len(rx.FindAllIndex(out, -1)); appliedPatches != len(patches) {
 		return nil, fmt.Errorf("expected %d applied patches, actually %d:\n\n%s", len(patches), appliedPatches, string(out))
 	}
 	return mod, nil

--- a/testdata/script/linker.txtar
+++ b/testdata/script/linker.txtar
@@ -1,3 +1,6 @@
+[!short] [exec:git] exec git init -q
+[!short] [exec:git] env GARBLE_CACHE_DIR=$WORK/linker-cache
+
 garble build
 exec ./main
 ! cmp stderr main.stderr


### PR DESCRIPTION
`git` is very smart and tries to find repository in parent directory. 
This is a very strange situation, but in our `modinfo` test, this is exactly what happens:

```
toor@root:/tmp/go-test-script3218627159/script-modinfo/.tmp/garble-shared3668927587/linker-src$ git log
commit 36f59e140927694cf85e88e1d4bf7440474f89c7 (HEAD -> master)
Author: name <name@email.local>
Date:   Wed Feb 8 00:38:26 2023 +0100

    very unique commit message
```

Fix prevents this behavior