### PR TITLE
drop Go 1.19, which allows resolving five TODOs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.20.x]
         # TODO: revert to macos-latest once we figure out https://github.com/burrowers/garble/issues/609.
         os: [ubuntu-latest, macos-11, windows-latest]
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 	go install mvdan.cc/garble@latest
 
-Obfuscate Go code by wrapping the Go toolchain. Requires Go 1.19 or later.
+Obfuscate Go code by wrapping the Go toolchain. Requires Go 1.20 or later.
 
 	garble build [build flags] [packages]
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module mvdan.cc/garble
 
-go 1.19
+go 1.20
 
 require (
 	github.com/bluekeyes/go-gitdiff v0.7.0

--- a/internal/literals/obfuscators.go
+++ b/internal/literals/obfuscators.go
@@ -22,7 +22,7 @@ var (
 		swap{},
 		split{},
 		shuffle{},
-		// seed{}, TODO: re-enable once https://go.dev/issue/47631 is fixed in Go 1.20
+		seed{},
 	}
 
 	TestObfuscator         string

--- a/main.go
+++ b/main.go
@@ -262,7 +262,7 @@ var toolchainVersionSemver string
 
 func goVersionOK() bool {
 	const (
-		minGoVersionSemver = "v1.19.0"
+		minGoVersionSemver = "v1.20.0"
 		suggestedGoVersion = "1.20.x"
 	)
 

--- a/main.go
+++ b/main.go
@@ -354,7 +354,7 @@ func mainErr(args []string) error {
 
 		// Until https://github.com/golang/go/issues/50603 is implemented,
 		// manually construct something like a pseudo-version.
-		// TODO: remove when this code is dead, hopefully in Go 1.20.
+		// TODO: remove when this code is dead, hopefully in Go 1.21.
 		if mod.Version == "(devel)" {
 			var vcsTime time.Time
 			var vcsRevision string
@@ -794,15 +794,8 @@ func replaceAsmNames(buf *bytes.Buffer, remaining []byte) {
 		// If the name was qualified, fetch the package, and write the
 		// obfuscated import path if needed.
 		// Note that we don't obfuscate the package path "main".
-		//
-		// Note that runtime/internal/startlinetest refers to runtime_test in
-		// one of its assembly files, and we currently do not always collect
-		// test packages in appendListedPackages for the sake of performance.
-		// We don't care about testing the runtime just yet, so work around it.
-		// TODO(mvdan): this runtime_test reference was removed in Go 1.20 per
-		// https://github.com/golang/go/issues/57334; remove at a later time.
 		lpkg := curPkg
-		if asmPkgPath != "" && asmPkgPath != "main" && asmPkgPath != "runtime_test" {
+		if asmPkgPath != "" && asmPkgPath != "main" {
 			if asmPkgPath != curPkg.Name {
 				goPkgPath := asmPkgPath
 				goPkgPath = strings.ReplaceAll(goPkgPath, string(asmPeriod), string(goPeriod))

--- a/main_test.go
+++ b/main_test.go
@@ -315,8 +315,6 @@ func grepfiles(ts *testscript.TestScript, neg bool, args []string) {
 	anyFound := false
 	path, pattern := args[0], args[1]
 	rx := regexp.MustCompile(pattern)
-	// TODO: use fs.SkipAll in Go 1.20 and later.
-	errSkipAll := fmt.Errorf("sentinel error: stop walking")
 	if err := filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -326,11 +324,11 @@ func grepfiles(ts *testscript.TestScript, neg bool, args []string) {
 				return fmt.Errorf("%q matches %q", path, pattern)
 			} else {
 				anyFound = true
-				return errSkipAll
+				return fs.SkipAll
 			}
 		}
 		return nil
-	}); err != nil && err != errSkipAll {
+	}); err != nil {
 		ts.Fatalf("%s", err)
 	}
 	if !neg && !anyFound {

--- a/shared.go
+++ b/shared.go
@@ -278,22 +278,6 @@ func appendListedPackages(packages []string, withDeps bool) error {
 			pkg.GarbleActionID = addGarbleToHash(actionID)
 		}
 
-		// Work around https://go.dev/issue/28749:
-		// cmd/go puts assembly, C, and C++ files in CompiledGoFiles.
-		//
-		// TODO: Fixed in Go 1.20; remove once we drop support for Go 1.19.
-		out := pkg.CompiledGoFiles[:0]
-		for _, path := range pkg.CompiledGoFiles {
-			switch filepath.Ext(path) {
-			case "": // e.g. a generated Go file inside the build cache
-			case ".go":
-			default: // e.g. an assembly file
-				continue
-			}
-			out = append(out, path)
-		}
-		pkg.CompiledGoFiles = out
-
 		cache.ListedPackages[pkg.ImportPath] = &pkg
 	}
 

--- a/testdata/script/asm.txtar
+++ b/testdata/script/asm.txtar
@@ -33,7 +33,7 @@ binsubstr main$exe 'addJmp' 'AddImpl'
 -- go.mod --
 module test/with.many.dots/main
 
-go 1.19
+go 1.20
 -- main.go --
 package main
 

--- a/testdata/script/basic.txtar
+++ b/testdata/script/basic.txtar
@@ -59,7 +59,7 @@ binsubstr main$exe 'garble_main.go' 'globalVar' 'globalFunc' $gofullversion
 -- go.mod --
 module test/mainfoo
 
-go 1.19
+go 1.20
 -- garble_main.go --
 package main
 

--- a/testdata/script/cgo.txtar
+++ b/testdata/script/cgo.txtar
@@ -29,7 +29,7 @@ binsubstr main$exe 'privateAdd'
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- main.go --
 package main
 

--- a/testdata/script/crossbuild.txtar
+++ b/testdata/script/crossbuild.txtar
@@ -18,11 +18,10 @@
 [arm] env GOARCH=arm64
 garble build -gcflags=math/bits=-d=ssa/intrinsics/debug=1
 stderr 'intrinsic substitution for Len64.*BitLen64'
-
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- main.go --
 package main
 

--- a/testdata/script/debugdir.txtar
+++ b/testdata/script/debugdir.txtar
@@ -18,7 +18,7 @@ stderr 'test/main' # we force rebuilds with -debugdir
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- main.go --
 package main
 

--- a/testdata/script/embed.txtar
+++ b/testdata/script/embed.txtar
@@ -11,7 +11,7 @@ cmp stdout main.stdout
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- main.go --
 package main
 

--- a/testdata/script/goenv.txtar
+++ b/testdata/script/goenv.txtar
@@ -46,7 +46,7 @@ exec $NAME/garble$exe build
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- main.go --
 package main
 

--- a/testdata/script/gogarble.txtar
+++ b/testdata/script/gogarble.txtar
@@ -51,7 +51,7 @@ bincmp out_rebuild out
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- standalone/main.go --
 package main
 

--- a/testdata/script/goversion.txtar
+++ b/testdata/script/goversion.txtar
@@ -23,7 +23,7 @@ stderr 'Go version "devel go1\.15-.*2020.*" is too old; please upgrade to Go 1\.
 # A current devel version should be fine.
 # Note that we don't look at devel version timestamps.
 env GARBLE_TEST_GOVERSION='go1.20'
-env TOOLCHAIN_GOVERSION='devel go1.20-ad97d204f0 Sun Sep 12 16:46:58 2021 +0000'
+env TOOLCHAIN_GOVERSION='devel go1.20-ad97d204f0 Sun Sep 12 16:46:58 2023 +0000'
 ! garble build
 stderr 'mocking the real build'
 
@@ -45,40 +45,40 @@ env TOOLCHAIN_GOVERSION='devel go1.20-somecustomversion'
 stderr 'mocking the real build'
 
 # The current toolchain may be older than the one that built garble.
-env GARBLE_TEST_GOVERSION='go1.20'
-env TOOLCHAIN_GOVERSION='go1.19.3'
+env GARBLE_TEST_GOVERSION='go1.21'
+env TOOLCHAIN_GOVERSION='go1.20.3'
 ! garble build
 stderr 'mocking the real build'
 
 # The current toolchain may be equal to the one that built garble.
-env GARBLE_TEST_GOVERSION='devel go1.19-6673d5d701 Sun Mar 20 16:05:03 2022 +0000'
-env TOOLCHAIN_GOVERSION='devel go1.19-6673d5d701 Sun Mar 20 16:05:03 2022 +0000'
+env GARBLE_TEST_GOVERSION='devel go1.20-6673d5d701 Sun Mar 20 16:05:03 2023 +0000'
+env TOOLCHAIN_GOVERSION='devel go1.20-6673d5d701 Sun Mar 20 16:05:03 2023 +0000'
 ! garble build
 stderr 'mocking the real build'
 
 # The current toolchain must not be newer than the one that built garble.
 env GARBLE_TEST_GOVERSION='go1.18'
-env TOOLCHAIN_GOVERSION='go1.19.1'
+env TOOLCHAIN_GOVERSION='go1.20.1'
 ! garble build
-stderr 'garble was built with "go1\.18" and is being used with "go1\.19\.1"; please rebuild garble with the newer version'
+stderr 'garble was built with "go1\.18" and is being used with "go1\.20\.1"; please rebuild garble with the newer version'
 
 # We'll error even if the difference is a minor (bugfix) level.
 # In practice it probably wouldn't matter, but in theory it could still lead to tricky bugs.
-env GARBLE_TEST_GOVERSION='go1.19.11'
-env TOOLCHAIN_GOVERSION='go1.19.14'
+env GARBLE_TEST_GOVERSION='go1.20.11'
+env TOOLCHAIN_GOVERSION='go1.20.14'
 ! garble build
-stderr 'garble was built with "go1\.19\.11" and is being used with "go1\.19\.14"; please rebuild garble with the newer version'
+stderr 'garble was built with "go1\.20\.11" and is being used with "go1\.20\.14"; please rebuild garble with the newer version'
 
 # If garble builds itself and is then used, it won't know what version built it.
 # As a fallback, we drop the comparison against the toolchain's version.
 env GARBLE_TEST_GOVERSION='bogus version'
-env TOOLCHAIN_GOVERSION='go1.19.3'
+env TOOLCHAIN_GOVERSION='go1.20.3'
 ! garble build
 stderr 'mocking the real build'
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- main.go --
 package main
 

--- a/testdata/script/help.txtar
+++ b/testdata/script/help.txtar
@@ -117,6 +117,6 @@ stderr 'usage: garble version'
 -- go.mod --
 module dummy
 
-go 1.19
+go 1.20
 -- dummy.go --
 package dummy

--- a/testdata/script/implement.txtar
+++ b/testdata/script/implement.txtar
@@ -13,7 +13,7 @@ cmp stdout main.stdout
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- main.go --
 package main
 

--- a/testdata/script/imports.txtar
+++ b/testdata/script/imports.txtar
@@ -42,7 +42,7 @@ cmp stdout main.stdout
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 
 require (
 	gopkg.in/garbletest.v2 v2.999.0

--- a/testdata/script/init.txtar
+++ b/testdata/script/init.txtar
@@ -12,7 +12,7 @@ cmp stderr main.stderr
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- main.go --
 package main
 

--- a/testdata/script/ldflags.txtar
+++ b/testdata/script/ldflags.txtar
@@ -28,7 +28,7 @@ binsubstr main$exe 'unexportedVersion' 'ExportedUnset' 'v1.22.33' 'garble_replac
 -- go.mod --
 module domain.test/main
 
-go 1.19
+go 1.20
 -- main.go --
 package main
 

--- a/testdata/script/linker.txtar
+++ b/testdata/script/linker.txtar
@@ -15,8 +15,7 @@ cmp stderr main.stderr
 -- go.mod --
 module test/main
 
-go 1.19
-
+go 1.20
 -- main.go --
 package main
 

--- a/testdata/script/linkname.txtar
+++ b/testdata/script/linkname.txtar
@@ -14,7 +14,7 @@ cmp stderr main.stderr
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 
 replace big.chungus/meme => ./big.chungus/meme
 
@@ -149,7 +149,7 @@ func ByteIndex(s string, c byte) int
 -- big.chungus/meme/go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- big.chungus/meme/dante.go --
 package meme
 

--- a/testdata/script/literals.txtar
+++ b/testdata/script/literals.txtar
@@ -44,9 +44,8 @@ grep '^\s+\w+ \^= \w+ \* \w+$' debug1/test/main/extra_literals.go
 # Note that the line obfuscator adds an inline comment before the call.
 grep '^\s+\w+ = .*\bappend\(\w+,(\s+\w+\[\d+\][\^\-+]\w+\[\d+\],?)+\)$' debug1/test/main/extra_literals.go
 
-# TODO: re-enable once https://github.com/golang/go/issues/47631 is fixed
 # XorSeed obfuscator. Detect type decFunc func(byte) decFunc
-# grep '^\s+type \w+ func\(byte\) \w+$' debug1/test/main/extra_literals.go 
+grep '^\s+type \w+ func\(byte\) \w+$' debug1/test/main/extra_literals.go
 
 # Finally, sanity check that we can build all of std with -literals.
 # Analogous to gogarble.txt.

--- a/testdata/script/literals.txtar
+++ b/testdata/script/literals.txtar
@@ -54,7 +54,7 @@ garble -literals build std
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- main.go --
 package main
 

--- a/testdata/script/modinfo.txtar
+++ b/testdata/script/modinfo.txtar
@@ -26,7 +26,7 @@ stdout 'build\s*vcs.revision='${HEAD_COMMIT_SHA}
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- main.go --
 package main
 

--- a/testdata/script/plugin.txtar
+++ b/testdata/script/plugin.txtar
@@ -26,7 +26,7 @@ cmp stderr main.stderr
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- plugin/main.go --
 package main
 

--- a/testdata/script/position.txtar
+++ b/testdata/script/position.txtar
@@ -16,7 +16,7 @@ stdout 'varPositions is sorted'
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- garble_main.go --
 package main
 

--- a/testdata/script/reflect.txtar
+++ b/testdata/script/reflect.txtar
@@ -14,7 +14,7 @@ cmp stdout main.stdout
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- garble_main.go --
 package main
 

--- a/testdata/script/reverse.txtar
+++ b/testdata/script/reverse.txtar
@@ -54,7 +54,7 @@ cmp stdout main-literals.stderr
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- long_main.go --
 package main
 

--- a/testdata/script/reverse.txtar
+++ b/testdata/script/reverse.txtar
@@ -28,8 +28,7 @@ cp stderr build-error.stderr
 
 stdin build-error.stderr
 garble reverse ./build-error
-[!go1.20] cmp stdout build-error-reverse.stdout-go1.19
-[go1.20] cmp stdout build-error-reverse.stdout-go1.20
+cmp stdout build-error-reverse.stdout
 
 [short] stop # no need to verify this with -short
 
@@ -157,12 +156,7 @@ main.main(...)
 	test/main/long_main.go:11 +0x??
 
 main filename: test/main/long_main.go
--- build-error-reverse.stdout-go1.19 --
-# test/main/build-error
-test/main/build-error/error.go:18: cannot convert UnobfuscatedStruct{} (value of type UnobfuscatedStruct) to type struct{SomeField int}
-exit status 2
-exit status 2
--- build-error-reverse.stdout-go1.20 --
+-- build-error-reverse.stdout --
 # test/main/build-error
 test/main/build-error/error.go:18: cannot convert UnobfuscatedStruct{} (value of type UnobfuscatedStruct) to type struct{SomeField int}
 exit status 2

--- a/testdata/script/seed-cache.txtar
+++ b/testdata/script/seed-cache.txtar
@@ -32,7 +32,7 @@ cd ..
 -- mod1/go.mod --
 module test/main/mod1
 
-go 1.19
+go 1.20
 
 require gopkg.in/garbletest.v2 v2.999.0
 
@@ -52,7 +52,7 @@ func main() { garbletest.Test() }
 -- mod2/go.mod --
 module test/main/mod2
 
-go 1.19
+go 1.20
 
 require gopkg.in/garbletest.v2 v2.999.0
 

--- a/testdata/script/seed.txtar
+++ b/testdata/script/seed.txtar
@@ -96,7 +96,7 @@ cmp stderr importedpkg.stderr
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- main.go --
 package main
 

--- a/testdata/script/syntax.txtar
+++ b/testdata/script/syntax.txtar
@@ -16,7 +16,7 @@ binsubstr main$exe 'globalVar' # 'globalType' matches on some, but not all, plat
 -- extra/go.mod --
 module private.source/extra
 
-go 1.19
+go 1.20
 -- extra/extra.go --
 package extra
 
@@ -26,7 +26,7 @@ func Func() string {
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 
 // We include an extra module to obfuscate, included in the same original source
 // code via a replace directive.

--- a/testdata/script/test.txtar
+++ b/testdata/script/test.txtar
@@ -52,7 +52,7 @@ stdout 'package bar_test, func name: test/bar\.OriginalFuncName'
 -- go.mod --
 module test/bar
 
-go 1.19
+go 1.20
 -- bar.go --
 package bar
 

--- a/testdata/script/tiny.txtar
+++ b/testdata/script/tiny.txtar
@@ -27,7 +27,7 @@ stderr 'funcStructExported false funcStructUnexported false'
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- garble_main.go --
 package main
 

--- a/testdata/script/typeparams.txtar
+++ b/testdata/script/typeparams.txtar
@@ -3,7 +3,7 @@ garble build
 -- go.mod --
 module test/main
 
-go 1.19
+go 1.20
 -- garble_main.go --
 package main
 


### PR DESCRIPTION
(see commit messages - please do not squash)

