### PR TITLE
use fewer build flags when building std or cmd

### DIFF
--- a/main.go
+++ b/main.go
@@ -563,11 +563,7 @@ This command wraps "go %s". Below is its help:
 		}
 	}
 
-	goArgs := []string{
-		command,
-		"-trimpath",
-		"-buildvcs=false",
-	}
+	goArgs := append([]string{command}, garbleBuildFlags...)
 
 	// Pass the garble flags down to each toolexec invocation.
 	// This way, all garble processes see the same flag values.

--- a/testdata/script/linker.txtar
+++ b/testdata/script/linker.txtar
@@ -1,7 +1,12 @@
 # Past garble versions might not properly patch cmd/link with "git apply"
 # when running inside a git repository. Skip the extra check with -short.
 [!short] [exec:git] exec git init -q
-[!short] [exec:git] env GARBLE_CACHE_DIR=$WORK/linker-cache
+[!short] [exec:git] env GARBLE_CACHE_DIR=${WORK}/linker-cache
+
+# Any build settings for the main build shouldn't affect building the linker.
+# If this flag makes it through when using build commands on std or cmd,
+# those commands are likely to fail as std and cmd are their own modules.
+env GOFLAGS=-modfile=${WORK}/go.mod
 
 garble build
 exec ./main


### PR DESCRIPTION
(see commit message)

