### PR TITLE
Simple obfuscation for large literals

### DIFF
--- a/internal/literals/obfuscators.go
+++ b/internal/literals/obfuscators.go
@@ -16,13 +16,20 @@ type obfuscator interface {
 }
 
 var (
+	simpleObfuscator = simple{}
+
 	// Obfuscators contains all types which implement the obfuscator Interface
 	Obfuscators = []obfuscator{
-		simple{},
+		simpleObfuscator,
 		swap{},
 		split{},
 		shuffle{},
 		seed{},
+	}
+
+	// LinearTimeObfuscators contains all types which implement the obfuscator Interface and can safely be used on large literals
+	LinearTimeObfuscators = []obfuscator{
+		simpleObfuscator,
 	}
 
 	TestObfuscator         string
@@ -82,6 +89,13 @@ func (r *obfRand) nextObfuscator() obfuscator {
 		return r.testObfuscator
 	}
 	return Obfuscators[r.Intn(len(Obfuscators))]
+}
+
+func (r *obfRand) nextLinearTimeObfuscator() obfuscator {
+	if r.testObfuscator != nil {
+		return r.testObfuscator
+	}
+	return Obfuscators[r.Intn(len(LinearTimeObfuscators))]
 }
 
 func newObfRand(rand *mathrand.Rand, file *ast.File) *obfRand {

--- a/testdata/script/literals.txtar
+++ b/testdata/script/literals.txtar
@@ -26,14 +26,14 @@ binsubstr main$exe 'Lorem Ipsum' 'dolor sit amet' 'second assign' 'First Line' '
 generate-literals extra_literals.go
 
 # ensure we find the extra literals in an unobfuscated build
-go build -o=out
-binsubstr out 'a_unique_string_that_is_part_of_all_extra_literals'
+go build
+binsubstr main$exe 'a_unique_string_that_is_part_of_all_extra_literals'
 
 # ensure we don't find the extra literals in an obfuscated build
-garble -literals -debugdir=debug1 build -o=out
+garble -literals -debugdir=debug1 build
 exec ./main$exe
 cmp stderr main.stderr
-! binsubstr out 'a_unique_string_that_is_part_of_all_extra_literals'
+! binsubstr main$exe 'a_unique_string_that_is_part_of_all_extra_literals'
 
 # Check obfuscators.
 

--- a/testdata/script/literals.txtar
+++ b/testdata/script/literals.txtar
@@ -25,9 +25,15 @@ binsubstr main$exe 'Lorem Ipsum' 'dolor sit amet' 'second assign' 'First Line' '
 # seconds, it means we're trying to obfuscate them.
 generate-literals extra_literals.go
 
-garble -literals -debugdir=debug1 build
+# ensure we find the extra literals in an unobfuscated build
+go build -o=out
+binsubstr out 'a_unique_string_that_is_part_of_all_extra_literals'
+
+# ensure we don't find the extra literals in an obfuscated build
+garble -literals -debugdir=debug1 build -o=out
 exec ./main$exe
 cmp stderr main.stderr
+! binsubstr out 'a_unique_string_that_is_part_of_all_extra_literals'
 
 # Check obfuscators.
 


### PR DESCRIPTION
Changes literal obfuscation such that literals of any size will be obfuscated, but beyond `maxSize` we only use the [simple](https://github.com/burrowers/garble/blob/master/internal/literals/simple.go#L14) obfuscator. This one seems to apply one of the AND, OR or XOR operators byte-wise and should be safe to use.

The test for literals is changed a bit to verify that obfuscation is applied. The code written to the `extra_literals.go` file by the test helper now creates an `init` function with `Printf` statements inside. This way Go does not optimize the literals away when we compile. We also append a unique string to all literals so that we can test that an unobfuscated build contains this string while an obfuscated build does not.