### PR TITLE
ssaReflect

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileDirname}"
+        }
+    ]
+}

--- a/go_std_tables.go
+++ b/go_std_tables.go
@@ -194,3 +194,7 @@ var compilerIntrinsicsFuncs = map[string]bool{
 	"sync.runtime_LoadAcquintptr":             true,
 	"sync.runtime_StoreReluintptr":            true,
 }
+
+var reflectSkipPkg = map[string]bool{
+	"fmt": true,
+}

--- a/main.go
+++ b/main.go
@@ -35,11 +35,12 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"golang.org/x/mod/module"
 	"golang.org/x/mod/semver"
 	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/ssa"
+
 	"mvdan.cc/garble/internal/linker"
 	"mvdan.cc/garble/internal/literals"
 )
@@ -78,8 +79,6 @@ func (f seedFlag) String() string {
 
 func (f *seedFlag) Set(s string) error {
 	if s == "random" {
-		f.random = true // to show the random seed we chose
-
 		f.bytes = make([]byte, 16) // random 128 bit seed
 		if _, err := cryptorand.Read(f.bytes); err != nil {
 			return fmt.Errorf("error generating random seed: %v", err)
@@ -121,7 +120,6 @@ The following commands are supported:
 
 	build          replace "go build"
 	test           replace "go test"
-	run            replace "go run"
 	reverse        de-obfuscate output such as stack traces
 	version        print the version and build settings of the garble binary
 
@@ -237,20 +235,18 @@ func main1() int {
 		usage()
 		return 2
 	}
-
-	// If a random seed was used, the user won't be able to reproduce the
-	// same output or failure unless we print the random seed we chose.
-	// If the build failed and a random seed was used,
-	// the failure might not reproduce with a different seed.
-	// Print it before we exit.
-	if flagSeed.random {
-		fmt.Fprintf(os.Stderr, "-seed chosen at random: %s\n", base64.RawStdEncoding.EncodeToString(flagSeed.bytes))
-	}
 	if err := mainErr(args); err != nil {
 		if code, ok := err.(errJustExit); ok {
 			return int(code)
 		}
 		fmt.Fprintln(os.Stderr, err)
+
+		// If the build failed and a random seed was used,
+		// the failure might not reproduce with a different seed.
+		// Print it before we exit.
+		if flagSeed.random {
+			fmt.Fprintf(os.Stderr, "random seed: %s\n", base64.RawStdEncoding.EncodeToString(flagSeed.bytes))
+		}
 		return 1
 	}
 	return 0
@@ -259,6 +255,11 @@ func main1() int {
 type errJustExit int
 
 func (e errJustExit) Error() string { return fmt.Sprintf("exit: %d", e) }
+
+// toolchainVersionSemver is a semver-compatible version of the Go toolchain currently
+// being used, as reported by "go env GOVERSION".
+// Note that the version of Go that built the garble binary might be newer.
+var toolchainVersionSemver string
 
 func goVersionOK() bool {
 	const (
@@ -270,7 +271,7 @@ func goVersionOK() bool {
 	rxVersion := regexp.MustCompile(`go\d+\.\d+(?:\.\d+)?`)
 
 	toolchainVersionFull := cache.GoEnv.GOVERSION
-	toolchainVersion := rxVersion.FindString(toolchainVersionFull)
+	toolchainVersion := rxVersion.FindString(cache.GoEnv.GOVERSION)
 	if toolchainVersion == "" {
 		// Go 1.15.x and older do not have GOVERSION yet.
 		// We could go the extra mile and fetch it via 'go toolchainVersion',
@@ -279,14 +280,14 @@ func goVersionOK() bool {
 		return false
 	}
 
-	cache.GoVersionSemver = "v" + strings.TrimPrefix(toolchainVersion, "go")
-	if semver.Compare(cache.GoVersionSemver, minGoVersionSemver) < 0 {
+	toolchainVersionSemver = "v" + strings.TrimPrefix(toolchainVersion, "go")
+	if semver.Compare(toolchainVersionSemver, minGoVersionSemver) < 0 {
 		fmt.Fprintf(os.Stderr, "Go version %q is too old; please upgrade to Go %s or newer\n", toolchainVersionFull, suggestedGoVersion)
 		return false
 	}
 
 	// Ensure that the version of Go that built the garble binary is equal or
-	// newer than cache.GoVersionSemver.
+	// newer than toolchainVersionSemver.
 	builtVersionFull := os.Getenv("GARBLE_TEST_GOVERSION")
 	if builtVersionFull == "" {
 		builtVersionFull = runtime.Version()
@@ -298,7 +299,7 @@ func goVersionOK() bool {
 		return true
 	}
 	builtVersionSemver := "v" + strings.TrimPrefix(builtVersion, "go")
-	if semver.Compare(builtVersionSemver, cache.GoVersionSemver) < 0 {
+	if semver.Compare(builtVersionSemver, toolchainVersionSemver) < 0 {
 		fmt.Fprintf(os.Stderr, "garble was built with %q and is being used with %q; please rebuild garble with the newer version\n",
 			builtVersionFull, toolchainVersionFull)
 		return false
@@ -392,7 +393,7 @@ func mainErr(args []string) error {
 		return nil
 	case "reverse":
 		return commandReverse(args)
-	case "build", "test", "run":
+	case "build", "test":
 		cmd, err := toolexecCmd(command, args)
 		defer os.RemoveAll(os.Getenv("GARBLE_SHARED"))
 		if err != nil {
@@ -441,7 +442,7 @@ func mainErr(args []string) error {
 
 		executablePath := args[0]
 		if tool == "link" {
-			modifiedLinkPath, unlock, err := linker.PatchLinker(cache.GoEnv.GOROOT, cache.GoEnv.GOVERSION, sharedTempDir)
+			modifiedLinkPath, unlock, err := linker.PatchLinker(cache.GoEnv.GOROOT, cache.GoEnv.GOVERSION, cache.GoEnv.GOEXE, sharedTempDir)
 			if err != nil {
 				return fmt.Errorf("cannot get modified linker: %v", err)
 			}
@@ -563,7 +564,11 @@ This command wraps "go %s". Below is its help:
 		}
 	}
 
-	goArgs := append([]string{command}, garbleBuildFlags...)
+	goArgs := []string{
+		command,
+		"-trimpath",
+		"-buildvcs=false",
+	}
 
 	// Pass the garble flags down to each toolexec invocation.
 	// This way, all garble processes see the same flag values.
@@ -904,7 +909,27 @@ func transformCompile(args []string) ([]string, error) {
 		return nil, err
 	}
 
-	tf.findReflectFunctions(files)
+	ssaProg := ssa.NewProgram(fset, 0)
+
+	// Create SSA packages for all imports.
+	// Order is not significant.
+	created := make(map[*types.Package]bool)
+	var createAll func(pkgs []*types.Package)
+	createAll = func(pkgs []*types.Package) {
+		for _, p := range pkgs {
+			if !created[p] {
+				created[p] = true
+				ssaProg.CreatePackage(p, nil, nil, true)
+				createAll(p.Imports())
+			}
+		}
+	}
+	createAll(tf.pkg.Imports())
+
+	ssaPkg := ssaProg.CreatePackage(tf.pkg, files, tf.info, false)
+	ssaPkg.Build()
+
+	tf.recordReflection(ssaPkg)
 	newImportCfg, err := processImportCfg(flags)
 	if err != nil {
 		return nil, err
@@ -1240,11 +1265,6 @@ type (
 	funcFullName = string // as per go/types.Func.FullName
 	objectString = string // as per recordedObjectString
 
-	reflectParameter struct {
-		Position int  // 0-indexed
-		Variadic bool // ...int
-	}
-
 	typeName struct {
 		PkgPath, Name string
 	}
@@ -1267,7 +1287,7 @@ var cachedOutput = struct {
 	//
 	// TODO: we're not including fmt.Printf, as it would have many false positives,
 	// unless we were smart enough to detect which arguments get used as %#v or %T.
-	KnownReflectAPIs map[funcFullName][]reflectParameter
+	KnownReflectAPIs map[funcFullName][]int
 
 	// KnownCannotObfuscate is filled with the fully qualified names from each
 	// package that we cannot obfuscate.
@@ -1283,9 +1303,9 @@ var cachedOutput = struct {
 	// bearing in mind that it may be owned by a different package.
 	KnownEmbeddedAliasFields map[objectString]typeName
 }{
-	KnownReflectAPIs: map[funcFullName][]reflectParameter{
-		"reflect.TypeOf":  {{Position: 0, Variadic: false}},
-		"reflect.ValueOf": {{Position: 0, Variadic: false}},
+	KnownReflectAPIs: map[funcFullName][]int{
+		"reflect.TypeOf":  {0},
+		"reflect.ValueOf": {0},
 	},
 	KnownCannotObfuscate:     map[objectString]struct{}{},
 	KnownEmbeddedAliasFields: map[objectString]typeName{},
@@ -1344,90 +1364,6 @@ func loadCachedOutputs() error {
 	return nil
 }
 
-func (tf *transformer) findReflectFunctions(files []*ast.File) {
-	seenReflectParams := make(map[*types.Var]bool)
-	visitFuncDecl := func(funcDecl *ast.FuncDecl) {
-		funcObj := tf.info.Defs[funcDecl.Name].(*types.Func)
-		funcType := funcObj.Type().(*types.Signature)
-		funcParams := funcType.Params()
-
-		maps.Clear(seenReflectParams)
-		for i := 0; i < funcParams.Len(); i++ {
-			seenReflectParams[funcParams.At(i)] = false
-		}
-
-		ast.Inspect(funcDecl, func(node ast.Node) bool {
-			call, ok := node.(*ast.CallExpr)
-			if !ok {
-				return true
-			}
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-			calledFunc, _ := tf.info.Uses[sel.Sel].(*types.Func)
-			if calledFunc == nil || calledFunc.Pkg() == nil {
-				return true
-			}
-
-			fullName := calledFunc.FullName()
-			for _, reflectParam := range cachedOutput.KnownReflectAPIs[fullName] {
-				// We need a range to handle any number of variadic arguments,
-				// which could be 0 or multiple.
-				// The non-variadic case is always one argument,
-				// but we still use the range to deduplicate code.
-				argStart := reflectParam.Position
-				argEnd := argStart + 1
-				if reflectParam.Variadic {
-					argEnd = len(call.Args)
-				}
-				for _, arg := range call.Args[argStart:argEnd] {
-					ident, ok := arg.(*ast.Ident)
-					if !ok {
-						continue
-					}
-					obj, _ := tf.info.Uses[ident].(*types.Var)
-					if obj == nil {
-						continue
-					}
-					if _, ok := seenReflectParams[obj]; ok {
-						seenReflectParams[obj] = true
-					}
-				}
-			}
-
-			var reflectParams []reflectParameter
-			for i := 0; i < funcParams.Len(); i++ {
-				if seenReflectParams[funcParams.At(i)] {
-					reflectParams = append(reflectParams, reflectParameter{
-						Position: i,
-						Variadic: funcType.Variadic() && i == funcParams.Len()-1,
-					})
-				}
-			}
-			if len(reflectParams) > 0 {
-				cachedOutput.KnownReflectAPIs[funcObj.FullName()] = reflectParams
-			}
-
-			return true
-		})
-	}
-
-	lenPrevKnownReflectAPIs := len(cachedOutput.KnownReflectAPIs)
-	for _, file := range files {
-		for _, decl := range file.Decls {
-			if decl, ok := decl.(*ast.FuncDecl); ok {
-				visitFuncDecl(decl)
-			}
-		}
-	}
-
-	// if a new reflectAPI is found we need to Re-evaluate all functions which might be using that API
-	if len(cachedOutput.KnownReflectAPIs) > lenPrevKnownReflectAPIs {
-		tf.findReflectFunctions(files)
-	}
-}
-
 // cmd/bundle will include a go:generate directive in its output by default.
 // Ours specifies a version and doesn't assume bundle is in $PATH, so drop it.
 
@@ -1480,46 +1416,6 @@ func (tf *transformer) prefillObjectMaps(files []*ast.File) error {
 		}
 		tf.linkerVariableStrings[obj] = stringValue
 	})
-
-	visit := func(node ast.Node) bool {
-		call, ok := node.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-
-		ident, ok := call.Fun.(*ast.Ident)
-		if !ok {
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-
-			ident = sel.Sel
-		}
-
-		fnType, _ := tf.info.Uses[ident].(*types.Func)
-		if fnType == nil || fnType.Pkg() == nil {
-			return true
-		}
-
-		fullName := fnType.FullName()
-		for _, reflectParam := range cachedOutput.KnownReflectAPIs[fullName] {
-			argStart := reflectParam.Position
-			argEnd := argStart + 1
-			if reflectParam.Variadic {
-				argEnd = len(call.Args)
-			}
-			for _, arg := range call.Args[argStart:argEnd] {
-				argType := tf.info.TypeOf(arg)
-				tf.recursivelyRecordAsNotObfuscated(argType)
-			}
-		}
-
-		return true
-	}
-	for _, file := range files {
-		ast.Inspect(file, visit)
-	}
 	return nil
 }
 
@@ -1548,10 +1444,13 @@ type transformer struct {
 func newTransformer() *transformer {
 	return &transformer{
 		info: &types.Info{
-			Types:     make(map[ast.Expr]types.TypeAndValue),
-			Defs:      make(map[*ast.Ident]types.Object),
-			Uses:      make(map[*ast.Ident]types.Object),
-			Implicits: make(map[ast.Node]types.Object),
+			Types:      make(map[ast.Expr]types.TypeAndValue),
+			Defs:       make(map[*ast.Ident]types.Object),
+			Uses:       make(map[*ast.Ident]types.Object),
+			Implicits:  make(map[ast.Node]types.Object),
+			Scopes:     make(map[ast.Node]*types.Scope),
+			Selections: make(map[*ast.SelectorExpr]*types.Selection),
+			Instances:  make(map[*ast.Ident]types.Instance),
 		},
 		recordTypeDone: make(map[*types.Named]bool),
 		fieldToStruct:  make(map[*types.Var]*types.Struct),
@@ -1652,7 +1551,6 @@ func (tf *transformer) recordType(used, origin types.Type) {
 // if that shows an improvement in our benchmark
 
 func recordedObjectString(obj types.Object) objectString {
-	pkg := obj.Pkg()
 	if obj, ok := obj.(*types.Var); ok && obj.IsField() {
 		// For exported fields, "pkgpath.Field" is not unique,
 		// because two exported top-level types could share "Field".
@@ -1669,7 +1567,7 @@ func recordedObjectString(obj types.Object) objectString {
 		// numbers, but not column numbers nor byte offsets.
 		// TODO(mvdan): give this another think, and add tests involving anon types.
 		pos := fset.Position(obj.Pos())
-		return fmt.Sprintf("%s.%s - %s:%d", pkg.Path(), obj.Name(),
+		return fmt.Sprintf("%s.%s - %s:%d", obj.Pkg().Path(), obj.Name(),
 			filepath.Base(pos.Filename), pos.Line)
 	}
 	// Names which are not at the top level cannot be imported,
@@ -1677,64 +1575,6 @@ func recordedObjectString(obj types.Object) objectString {
 	// Note that this doesn't apply to fields, which are never top-level.
 	if pkg.Scope() != obj.Parent() {
 		return ""
-	}
-	// For top-level exported names, "pkgpath.Name" is unique.
-	return pkg.Path() + "." + obj.Name()
-}
-
-// recordAsNotObfuscated records all the objects whose names we cannot obfuscate.
-// An object is any named entity, such as a declared variable or type.
-//
-// As of June 2022, this only records types which are used in reflection.
-// TODO(mvdan): If this is still the case in a year's time,
-// we should probably rename "not obfuscated" and "cannot obfuscate" to be
-// directly about reflection, e.g. "used in reflection".
-func recordAsNotObfuscated(obj types.Object) {
-	if obj.Pkg().Path() != curPkg.ImportPath {
-		panic("called recordedAsNotObfuscated with a foreign object")
-	}
-	if !obj.Exported() {
-		// Unexported names will never be used by other packages,
-		// so we don't need to bother recording them in cachedOutput.
-		knownCannotObfuscateUnexported[obj] = true
-		return
-	}
-
-	objStr := recordedObjectString(obj)
-	if objStr == "" {
-		// If the object can't be described via a qualified string,
-		// then other packages can't use it.
-		// TODO: should we still record it in knownCannotObfuscateUnexported?
-		return
-	}
-	cachedOutput.KnownCannotObfuscate[objStr] = struct{}{}
-}
-
-func recordedAsNotObfuscated(obj types.Object) bool {
-	if knownCannotObfuscateUnexported[obj] {
-		return true
-	}
-	objStr := recordedObjectString(obj)
-	if objStr == "" {
-		return false
-	}
-	_, ok := cachedOutput.KnownCannotObfuscate[objStr]
-	return ok
-}
-
-// isSafeForInstanceType returns true if the passed type is safe for var declaration.
-// Unsafe types: generic types and non-method interfaces.
-func isSafeForInstanceType(typ types.Type) bool {
-	switch t := typ.(type) {
-	case *types.Named:
-		if t.TypeParams().Len() > 0 {
-			return false
-		}
-		return isSafeForInstanceType(t.Underlying())
-	case *types.Signature:
-		return t.TypeParams().Len() == 0
-	case *types.Interface:
-		return t.IsMethodSet()
 	}
 	return true
 }
@@ -1907,10 +1747,6 @@ func (tf *transformer) transformGoFile(file *ast.File) *ast.File {
 		// match any field or method named FS.
 		path := pkg.Path()
 		switch path {
-		case "sync/atomic", "runtime/internal/atomic":
-			if name == "align64" {
-				return true
-			}
 		case "embed":
 			// FS is detected by the compiler for //go:embed.
 			// TODO: We probably want a conditional, otherwise we're not
@@ -1928,15 +1764,6 @@ func (tf *transformer) transformGoFile(file *ast.File) *ast.File {
 			// At least it's enough to leave the rtype and Value types intact.
 			case "rtype", "Value":
 				tf.recursivelyRecordAsNotObfuscated(obj.Type())
-				return true
-			}
-		case "crypto/x509/pkix":
-			// For better or worse, encoding/asn1 detects a "SET" suffix on slice type names
-			// to tell whether those slices should be treated as sets or sequences.
-			// Do not obfuscate those names to prevent breaking x509 certificates.
-			// TODO: we can surely do better; ideally propose a non-string-based solution
-			// upstream, or as a fallback, obfuscate to a name ending with "SET".
-			if strings.HasSuffix(name, "SET") {
 				return true
 			}
 		}
@@ -2056,50 +1883,6 @@ func (tf *transformer) transformGoFile(file *ast.File) *ast.File {
 	}
 
 	return astutil.Apply(file, pre, post).(*ast.File)
-}
-
-// recursivelyRecordAsNotObfuscated calls recordAsNotObfuscated on any named
-// types and fields under typ.
-//
-// Only the names declared in the current package are recorded. This is to ensure
-// that reflection detection only happens within the package declaring a type.
-// Detecting it in downstream packages could result in inconsistencies.
-func (tf *transformer) recursivelyRecordAsNotObfuscated(t types.Type) {
-	switch t := t.(type) {
-	case *types.Named:
-		obj := t.Obj()
-		if pkg := obj.Pkg(); pkg == nil || pkg != tf.pkg {
-			return // not from the specified package
-		}
-		if recordedAsNotObfuscated(obj) {
-			return // prevent endless recursion
-		}
-		recordAsNotObfuscated(obj)
-
-		// Record the underlying type, too.
-		tf.recursivelyRecordAsNotObfuscated(t.Underlying())
-
-	case *types.Struct:
-		for i := 0; i < t.NumFields(); i++ {
-			field := t.Field(i)
-
-			// This check is similar to the one in *types.Named.
-			// It's necessary for unnamed struct types,
-			// as they aren't named but still have named fields.
-			if field.Pkg() == nil || field.Pkg() != tf.pkg {
-				return // not from the specified package
-			}
-
-			// Record the field itself, too.
-			recordAsNotObfuscated(field)
-
-			tf.recursivelyRecordAsNotObfuscated(field.Type())
-		}
-
-	case interface{ Elem() types.Type }:
-		// Get past pointers, slices, etc.
-		tf.recursivelyRecordAsNotObfuscated(t.Elem())
-	}
 }
 
 // named tries to obtain the *types.Named behind a type, if there is one.
@@ -2391,7 +2174,7 @@ func flagSetValue(flags []string, name, value string) []string {
 func fetchGoEnv() error {
 	out, err := exec.Command("go", "env", "-json",
 		// Keep in sync with sharedCache.GoEnv.
-		"GOOS", "GOMOD", "GOVERSION", "GOROOT",
+		"GOOS", "GOMOD", "GOVERSION", "GOROOT", "GOEXE",
 	).CombinedOutput()
 	if err != nil {
 		// TODO: cover this in the tests.

--- a/reflect.go
+++ b/reflect.go
@@ -1,0 +1,455 @@
+package main
+
+import (
+	"fmt"
+	"go/types"
+	"path/filepath"
+
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+	"golang.org/x/tools/go/ssa"
+)
+
+var checkedAPIs = make(map[string]bool)
+
+// Record all instances of reflection use, and don't obfuscate types which are used in reflection.
+func (tf *transformer) recordReflection(ssaPkg *ssa.Package) {
+	if reflectSkipPkg[ssaPkg.Pkg.Name()] {
+		return
+	}
+
+	lenPrevKnownReflectAPIs := len(cachedOutput.KnownReflectAPIs)
+
+	// find all unchecked APIs to add them to checkedAPIs after the pass
+	notCheckedAPIs := make(map[string]bool)
+	for _, knownAPI := range maps.Keys(cachedOutput.KnownReflectAPIs) {
+		if !checkedAPIs[knownAPI] {
+			notCheckedAPIs[knownAPI] = true
+		}
+	}
+
+	tf.ignoreReflectedTypes(ssaPkg)
+
+	// all previously unchecked APIs have now been checked add them to checkedAPIs,
+	// to avoid checking them twice
+	maps.Copy(checkedAPIs, notCheckedAPIs)
+
+	// if a new reflectAPI is found we need to Re-evaluate all functions which might be using that API
+	if len(cachedOutput.KnownReflectAPIs) > lenPrevKnownReflectAPIs {
+		tf.recordReflection(ssaPkg)
+	}
+}
+
+func (tf *transformer) ignoreReflectedTypes(ssaPkg *ssa.Package) {
+	for _, memb := range ssaPkg.Members {
+		switch x := memb.(type) {
+		case *ssa.Type:
+			// methods aren't package members only their reciever types are
+			// so some logic is required to find the methods a type has
+
+			method := func(mset *types.MethodSet) {
+				for i, n := 0, mset.Len(); i < n; i++ {
+					at := mset.At(i)
+
+					if f := ssaPkg.Prog.MethodValue(at); f != nil {
+						tf.checkCalls(nil, f)
+					} else {
+						fun := at.Obj().(*types.Func)
+						// handle interfaces
+						tf.checkCalls(fun, nil)
+					}
+
+				}
+			}
+
+			// yes, finding all methods really only works with both calls
+			mset := ssaPkg.Prog.MethodSets.MethodSet(x.Type())
+			method(mset)
+
+			mset = ssaPkg.Prog.MethodSets.MethodSet(types.NewPointer(x.Type()))
+			method(mset)
+
+		case *ssa.Function:
+			// these not only include top level functions, but also synthetic
+			// functions like the initialization of global variables
+
+			tf.checkCalls(nil, x)
+		}
+	}
+}
+
+// Exported methods with unnamed structs as paramters may be "used" in interface declarations
+// elsewhere, these interfaces will break if any method uses reflection on the same parameter.
+//
+// Therefore never obfuscate unnamed structs which are used as a method parameter
+// and treat them like a parameter which is actually used in reflection.
+//
+// See "UnnamedStructMethod" in the reflect.txtar test for an example.
+func (tf *transformer) checkMethodSignature(reflectParams map[int]bool, sig *types.Signature) {
+	if sig.Recv() == nil {
+		return
+	}
+
+	params := sig.Params()
+	for i := 0; i < params.Len(); i++ {
+		if reflectParams[i] {
+			continue
+		}
+
+		ignore := false
+
+		param := params.At(i)
+
+		switch x := param.Type().(type) {
+		case *types.Struct:
+			ignore = true
+		case *types.Array:
+			if _, ok := x.Elem().(*types.Struct); ok {
+				ignore = true
+			}
+		case *types.Slice:
+			if _, ok := x.Elem().(*types.Struct); ok {
+				ignore = true
+			}
+		}
+
+		if ignore {
+			reflectParams[i] = true
+			tf.recursivelyRecordAsNotObfuscated(param.Type())
+		}
+	}
+}
+
+// Checks all callsites in a function declaration for use of reflection.
+// If a call to a function which uses reflection on a parameter is found
+// the type of the call argument is then
+func (tf *transformer) checkCalls(f *types.Func, fun *ssa.Function) {
+	if f != nil && fun != nil {
+		panic("either provide a *types.Func or a *ssa.Function not both")
+	}
+
+	/* 	if fun != nil && fun.Synthetic != "loaded from gc object file" {
+		// fun.WriteTo crashes otherwise
+		fun.WriteTo(os.Stdout)
+	} */
+
+	if f == nil {
+		f, _ = fun.Object().(*types.Func)
+	}
+
+	var sig *types.Signature
+	reflectParams := make(map[int]bool)
+	if f != nil {
+		sig = f.Type().(*types.Signature)
+		maps.Copy(reflectParams, cachedOutput.KnownReflectAPIs[f.FullName()])
+
+		if f.Exported() {
+			tf.checkMethodSignature(reflectParams, sig)
+		}
+	}
+
+	/* 	fmt.Printf("f: %v\n", f)
+	   	fmt.Printf("fun: %v\n", fun) */
+
+	if fun != nil {
+		for _, block := range fun.Blocks {
+			for _, inst := range block.Instrs {
+				/* 	fmt.Printf("inst: %v, t: %T\n", inst, inst) */
+				call, ok := inst.(*ssa.Call)
+				if !ok {
+					continue
+				}
+
+				callName := call.Call.Value.String()
+				if m := call.Call.Method; m != nil {
+					callName = call.Call.Method.FullName()
+				}
+
+				if checkedAPIs[callName] {
+					// only check apis which were not already checked
+					continue
+				}
+
+				/* fmt.Printf("callName: %v\n", callName) */
+
+				// record each call argument passed to a function parameter which is used in reflection
+				knownParams := cachedOutput.KnownReflectAPIs[callName]
+				for knownParam := range knownParams {
+					if len(call.Call.Args) <= knownParam {
+						continue
+					}
+
+					arg := call.Call.Args[knownParam]
+
+					/* fmt.Printf("flagging arg: %v\n", arg) */
+
+					visited := make(map[ssa.Value]bool)
+					reflectedParam := tf.recordArgReflected(arg, visited)
+					if reflectedParam == nil {
+						continue
+					}
+
+					pos := slices.Index(fun.Params, reflectedParam)
+					if pos < 0 {
+						continue
+					}
+
+					/* fmt.Printf("recorded param: %v func: %v\n", pos, fun) */
+
+					reflectParams[pos] = true
+				}
+			}
+		}
+	}
+
+	if len(reflectParams) > 0 {
+		cachedOutput.KnownReflectAPIs[f.FullName()] = reflectParams
+
+		/* fmt.Printf("cachedOutput.KnownReflectAPIs: %v\n", cachedOutput.KnownReflectAPIs) */
+	}
+}
+
+// recordArgReflected finds the type(s) of a function argument, which is being used in reflection
+// and excludes these types from obfuscation
+// It also checks if this argument has any relation to a function paramter and returns it if found.
+func (tf *transformer) recordArgReflected(val ssa.Value, visited map[ssa.Value]bool) *ssa.Parameter {
+	// make sure we visit every val only once, otherwise there will be infinite recursion
+	if visited[val] {
+		return nil
+	}
+
+	/* fmt.Printf("val: %v %T %v\n", val, val, val.Type()) */
+	visited[val] = true
+
+	switch val := val.(type) {
+	case *ssa.IndexAddr:
+		for _, ref := range *val.Referrers() {
+			if store, ok := ref.(*ssa.Store); ok {
+				tf.recordArgReflected(store.Val, visited)
+			}
+		}
+		return tf.recordArgReflected(val.X, visited)
+	case *ssa.Slice:
+		return tf.recordArgReflected(val.X, visited)
+	case *ssa.MakeInterface:
+		return tf.recordArgReflected(val.X, visited)
+	case *ssa.UnOp:
+		return tf.recordArgReflected(val.X, visited)
+	case *ssa.FieldAddr:
+		return tf.recordArgReflected(val.X, visited)
+
+	case *ssa.Alloc:
+		/* fmt.Printf("recording val %v \n", *val.Referrers()) */
+		tf.recursivelyRecordAsNotObfuscated(val.Type())
+
+		for _, ref := range *val.Referrers() {
+			if idx, ok := ref.(*ssa.IndexAddr); ok {
+				tf.recordArgReflected(idx, visited)
+			}
+		}
+
+		// relatedParam needs to revisit nodes so create an empty map
+		visited := make(map[ssa.Value]bool)
+
+		// check if the found alloc gets tainted by function parameters
+		return relatedParam(val, visited)
+
+	case *ssa.Const:
+		tf.recursivelyRecordAsNotObfuscated(val.Type())
+	case *ssa.Global:
+		tf.recursivelyRecordAsNotObfuscated(val.Type())
+
+		// TODO: this might need similar logic to *ssa.Alloc, however
+		// reassigning a function param to a global variable and then reflecting
+		// it is probably unlikely to occur
+	case *ssa.Parameter:
+		// this only finds the parameters who want to be found,
+		// otherwise relatedParam is used for more in depth analysis
+		return val
+	}
+
+	return nil
+}
+
+// relatedParam checks if a route to a function paramter can be constructed
+// from a ssa.Value, and returns the paramter if it found one.
+func relatedParam(val ssa.Value, visited map[ssa.Value]bool) *ssa.Parameter {
+	// every val should only be visited once to prevent infinite recursion
+	if visited[val] {
+		return nil
+	}
+
+	/* fmt.Printf("related val: %v %T %v\n", val, val, val.Type()) */
+
+	visited[val] = true
+
+	switch x := val.(type) {
+	case *ssa.Parameter:
+		// a paramter has been found
+		return x
+	case *ssa.UnOp:
+		if param := relatedParam(x.X, visited); param != nil {
+			return param
+		}
+	case *ssa.FieldAddr:
+		/* fmt.Printf("addr: %v\n", x)
+		fmt.Printf("addr.X: %v %T\n", x.X, x.X) */
+
+		if param := relatedParam(x.X, visited); param != nil {
+			return param
+		}
+	}
+
+	refs := val.Referrers()
+	if refs == nil {
+		return nil
+	}
+
+	for _, ref := range *refs {
+		/* fmt.Printf("ref: %v %T\n", ref, ref) */
+
+		var param *ssa.Parameter
+		switch ref := ref.(type) {
+		case *ssa.FieldAddr:
+			param = relatedParam(ref, visited)
+
+		case *ssa.UnOp:
+			param = relatedParam(ref, visited)
+
+		case *ssa.Store:
+			if param := relatedParam(ref.Val, visited); param != nil {
+				return param
+			}
+
+			param = relatedParam(ref.Addr, visited)
+
+		}
+
+		if param != nil {
+			return param
+		}
+
+	}
+
+	return nil
+}
+
+// recursivelyRecordAsNotObfuscated calls recordAsNotObfuscated on any named
+// types and fields under typ.
+//
+// Only the names declared in the current package are recorded. This is to ensure
+// that reflection detection only happens within the package declaring a type.
+// Detecting it in downstream packages could result in inconsistencies.
+func (tf *transformer) recursivelyRecordAsNotObfuscated(t types.Type) {
+	switch t := t.(type) {
+	case *types.Named:
+		obj := t.Obj()
+
+		// TODO: the transformer is only needed in this function, there is
+		// probably a way to do this with only the ssa information.
+		if obj.Pkg() == nil || obj.Pkg() != tf.pkg {
+			return // not from the specified package
+		}
+		if recordedAsNotObfuscated(obj) {
+			return // prevent endless recursion
+		}
+		recordAsNotObfuscated(obj)
+
+		// Record the underlying type, too.
+		tf.recursivelyRecordAsNotObfuscated(t.Underlying())
+
+	case *types.Struct:
+		for i := 0; i < t.NumFields(); i++ {
+			field := t.Field(i)
+
+			// This check is similar to the one in *types.Named.
+			// It's necessary for unnamed struct types,
+			// as they aren't named but still have named fields.
+			if field.Pkg() == nil || field.Pkg() != tf.pkg {
+				return // not from the specified package
+			}
+
+			// Record the field itself, too.
+			recordAsNotObfuscated(field)
+
+			tf.recursivelyRecordAsNotObfuscated(field.Type())
+		}
+
+	case interface{ Elem() types.Type }:
+		// Get past pointers, slices, etc.
+		tf.recursivelyRecordAsNotObfuscated(t.Elem())
+	}
+}
+
+// TODO: consider caching recordedObjectString via a map,
+// if that shows an improvement in our benchmark
+func recordedObjectString(obj types.Object) objectString {
+	pkg := obj.Pkg()
+	if obj, ok := obj.(*types.Var); ok && obj.IsField() {
+		// For exported fields, "pkgpath.Field" is not unique,
+		// because two exported top-level types could share "Field".
+		//
+		// Moreover, note that not all fields belong to named struct types;
+		// an API could be exposing:
+		//
+		//   var usedInReflection = struct{Field string}
+		//
+		// For now, a hack: assume that packages don't declare the same field
+		// more than once in the same line. This works in practice, but one
+		// could craft Go code to break this assumption.
+		// Also note that the compiler's object files include filenames and line
+		// numbers, but not column numbers nor byte offsets.
+		// TODO(mvdan): give this another think, and add tests involving anon types.
+		pos := fset.Position(obj.Pos())
+		return fmt.Sprintf("%s.%s - %s:%d", pkg.Path(), obj.Name(),
+			filepath.Base(pos.Filename), pos.Line)
+	}
+	// Names which are not at the top level cannot be imported,
+	// so we don't need to record them either.
+	// Note that this doesn't apply to fields, which are never top-level.
+	if pkg.Scope() != obj.Parent() {
+		return ""
+	}
+	// For top-level exported names, "pkgpath.Name" is unique.
+	return pkg.Path() + "." + obj.Name()
+}
+
+// recordAsNotObfuscated records all the objects whose names we cannot obfuscate.
+// An object is any named entity, such as a declared variable or type.
+//
+// As of June 2022, this only records types which are used in reflection.
+// TODO(mvdan): If this is still the case in a year's time,
+// we should probably rename "not obfuscated" and "cannot obfuscate" to be
+// directly about reflection, e.g. "used in reflection".
+func recordAsNotObfuscated(obj types.Object) {
+	if obj.Pkg().Path() != curPkg.ImportPath {
+		panic("called recordedAsNotObfuscated with a foreign object")
+	}
+	if !obj.Exported() {
+		// Unexported names will never be used by other packages,
+		// so we don't need to bother recording them in cachedOutput.
+		knownCannotObfuscateUnexported[obj] = true
+		return
+	}
+
+	objStr := recordedObjectString(obj)
+	if objStr == "" {
+		// If the object can't be described via a qualified string,
+		// then other packages can't use it.
+		// TODO: should we still record it in knownCannotObfuscateUnexported?
+		return
+	}
+	cachedOutput.KnownCannotObfuscate[objStr] = struct{}{}
+}
+
+func recordedAsNotObfuscated(obj types.Object) bool {
+	if knownCannotObfuscateUnexported[obj] {
+		return true
+	}
+	objStr := recordedObjectString(obj)
+	if objStr == "" {
+		return false
+	}
+	_, ok := cachedOutput.KnownCannotObfuscate[objStr]
+	return ok
+}

--- a/scripts/gen-go-std-tables.sh
+++ b/scripts/gen-go-std-tables.sh
@@ -53,4 +53,8 @@ $(while read path name; do
 	echo "\"${path}.${name}\": true,"
 done <<<"${compiler_intrinsics_table}")
 }
+
+var reflectSkipPkg = map[string]bool{
+	"fmt": true,
+}
 EOF

--- a/testdata/script/reflect.txtar
+++ b/testdata/script/reflect.txtar
@@ -115,6 +115,18 @@ func main() {
 	printfWithoutPackage("%#v\n", variadic)
 
 	testx509()
+
+
+	// Very complex reflection used by gorm
+	user := StatUser{}
+	find(&user)
+
+	// Similar to gorm with composite literals instead of direct assignments
+	userComp := StatCompUser{}
+	findComp(&userComp)
+
+	x := UnnamedStructInterface(importedpkg.ReflectUnnamedStruct(0))
+	x.UnnamedStructMethod(struct{ UnnamedStructField string }{UnnamedStructField: "field value"})
 }
 
 type EmbeddingIndirect struct {
@@ -205,11 +217,60 @@ func testx509() {
 	}
 }
 
+type StatUser struct {
+	Id      int64 `gorm:"primaryKey"`
+	User_Id int64
+}
+
+type StatCompUser struct {
+	Id      int64 `gorm:"primaryKey"`
+	User_Id int64
+}
+
+type Transaction struct {
+	Statement Statement
+}
+
+type Statement struct {
+	Dest  interface{}
+	Model string
+}
+
+func find(dest interface{}) {
+	tx := Transaction{}
+
+	tx.Statement.Dest = dest
+	execute(tx)
+}
+
+func findComp(dest interface{}) {
+	tx := Transaction{
+		Statement: Statement{
+			Dest: dest,
+		},
+	}
+
+	execute(tx)
+}
+
+func execute(db Transaction) {
+	stmt := db.Statement
+
+	v := reflect.TypeOf(stmt.Dest)
+
+	fmt.Println(v)
+}
+
+type UnnamedStructInterface interface {
+	UnnamedStructMethod(struct{ UnnamedStructField string })
+}
+
 
 -- importedpkg/imported.go --
 package importedpkg
 
 import (
+	"fmt"
 	"reflect"
 
 	"test/main/importedpkg/indirect"
@@ -282,14 +343,18 @@ type ReflectEmbeddingNamed struct{}
 
 func VariadicReflect(x any, ys ...any) int {
 	_ = reflect.TypeOf(x)
-	_ = reflect.TypeOf(ys)
 
-	// TODO: we likely do not notice indirect calls via a range like this.
 	for _, y := range ys {
 		_ = reflect.TypeOf(y)
 	}
 
 	return len(ys)
+}
+
+type ReflectUnnamedStruct int
+
+func (ReflectUnnamedStruct) UnnamedStructMethod(s struct{ UnnamedStructField string }) {
+	fmt.Println(reflect.TypeOf(s))
 }
 
 -- importedpkg2/imported2.go --
@@ -337,3 +402,4 @@ ReflectionField
 VariadicReflection{ReflectionField:"variadic"}
 *main.StatUser
 *main.StatCompUser
+struct { UnnamedStructField string }

--- a/testdata/script/reflect.txtar
+++ b/testdata/script/reflect.txtar
@@ -171,6 +171,16 @@ var _ = func() uintptr {
 	return field.Offset
 }()
 
+
+// copied from github.com/davecgh/go-spew, which reaches into reflect's internals
+var _ = func() uintptr {
+	field, ok := reflect.TypeOf(reflect.Value{}).FieldByName("flag")
+	if !ok {
+		panic("reflect.Value has no flag field")
+	}
+	return field.Offset
+}()
+
 // encoding/x509 uses encoding/asn1, which uses reflect.
 // In one place it depends on field names; that used to be broken by garble.
 func testx509() {

--- a/testdata/script/reflect.txtar
+++ b/testdata/script/reflect.txtar
@@ -325,3 +325,5 @@ IndirectNamedWithReflect{IndirectUnobfuscated:"indirect-with", DuplicateFieldNam
 ReflectionField
 {0}
 VariadicReflection{ReflectionField:"variadic"}
+*main.StatUser
+*main.StatCompUser


### PR DESCRIPTION
- scripts: remove TODO about building third party programs
- CI: test against a newer Go tip
- Add pagran to FUNDING.yml
- use fewer build flags when building std or cmd
- use git in english when matching its output
- use the host's GOEXE when building the linker
- avoid panic when a package's imports cannot be loaded
- ensure the alignment of sync/atomic types works
- update gotip and adapt to upstream changes
- avoid rebuilding garble in the main benchmark
- print chosen seed when building with -seed=random
- support `garble run`
- update gotip in CI and fix -tiny on the latest tip
- use the "simple" obfuscator for large literals
- update to Go tip from April 28th
- set testscript's RequireExplicitExec and RequireUniqueNames
- go.mod: bump deps
- scripts: no need for this directory to be a Go package
- CI: skip regular `go test` on linux
- add a test to reproduce our caching bugs
- fix encoding/asn1 marshaling of pkix types
- correctly detect indirect uses of reflection
- detect which objects are global in a simpler way
- avoid breaking github.com/davecgh/go-spew
- rework reflection detection with ssa
