### PR TITLE
avoid go:linkname warnings when building on tip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install Go
       env:
-        GO_COMMIT: aeb0644bd33e67f24e2411a651ac9ff72ddc96b4 # 2023-05-19
+        GO_COMMIT: 363713223385476b87dc5f26d267df8c67d13006 # 2023-06-03
       run: |
         cd $HOME
         mkdir $HOME/gotip

--- a/testdata/script/gogarble.txtar
+++ b/testdata/script/gogarble.txtar
@@ -29,11 +29,13 @@ env GOGARBLE='*'
 # Plus, some packages like net make heavy use of complex features like Cgo.
 # Note that we won't obfuscate a few std packages just yet, mainly those around runtime.
 exec garble build std
+! stderr . # no warnings
 
 # Link a binary importing net/http, which will catch whether or not we
 # support ImportMap when linking.
 # Also ensure we are obfuscating low-level std packages.
 exec garble build -o=out ./stdimporter
+! stderr . # no warnings
 ! binsubstr out 'http.ListenAndServe' 'debug.WriteHeapDump' 'time.Now' 'syscall.Listen'
 
 # The same low-level std packages appear in plain sight in regular builds.


### PR DESCRIPTION
(see commit message)

