### PR TITLE
remove the last "current package" globals, support computing missing cache entries

### DIFF
--- a/position.go
+++ b/position.go
@@ -18,8 +18,8 @@ var printBuf1, printBuf2 bytes.Buffer
 
 // printFile prints a Go file to a buffer, while also removing non-directive
 // comments and adding extra compiler directives to obfuscate position information.
-func printFile(file *ast.File) ([]byte, error) {
-	if curPkg.ToObfuscate {
+func printFile(lpkg *listedPackage, file *ast.File) ([]byte, error) {
+	if lpkg.ToObfuscate {
 		// Omit comments from the final Go code.
 		// Keep directives, as they affect the build.
 		// We do this before printing to print fewer bytes below.
@@ -45,7 +45,7 @@ func printFile(file *ast.File) ([]byte, error) {
 	}
 	src := printBuf1.Bytes()
 
-	if !curPkg.ToObfuscate {
+	if !lpkg.ToObfuscate {
 		// We lightly transform packages which shouldn't be obfuscated,
 		// such as when rewriting go:linkname directives to obfuscated packages.
 		// We still need to print the files, but without obfuscating positions.
@@ -127,7 +127,7 @@ func printFile(file *ast.File) ([]byte, error) {
 			newName := ""
 			if !flagTiny {
 				origPos := fmt.Sprintf("%s:%d", filename, origOffset)
-				newName = hashWithPackage(curPkg, origPos) + ".go"
+				newName = hashWithPackage(lpkg, origPos) + ".go"
 				// log.Printf("%q hashed with %x to %q", origPos, curPkg.GarbleActionID, newName)
 			}
 

--- a/reflect.go
+++ b/reflect.go
@@ -375,7 +375,7 @@ func (ri *reflectInspector) recursivelyRecordUsedForReflect(t types.Type) {
 		if obj.Pkg() == nil || obj.Pkg() != ri.pkg {
 			return // not from the specified package
 		}
-		if usedForReflect(obj) {
+		if usedForReflect(ri.result, obj) {
 			return // prevent endless recursion
 		}
 		ri.recordUsedForReflect(obj)
@@ -454,11 +454,11 @@ func (ri *reflectInspector) recordUsedForReflect(obj types.Object) {
 	ri.result.ReflectObjects[objStr] = struct{}{}
 }
 
-func usedForReflect(obj types.Object) bool {
+func usedForReflect(cache pkgCache, obj types.Object) bool {
 	objStr := recordedObjectString(obj)
 	if objStr == "" {
 		return false
 	}
-	_, ok := curPkgCache.ReflectObjects[objStr]
+	_, ok := cache.ReflectObjects[objStr]
 	return ok
 }

--- a/reverse.go
+++ b/reverse.go
@@ -70,8 +70,6 @@ One can reverse a captured panic stack trace as follows:
 		if !lpkg.ToObfuscate {
 			continue
 		}
-		curPkg = lpkg
-
 		addHashedWithPackage := func(str string) {
 			replaces = append(replaces, hashWithPackage(lpkg, str), str)
 		}
@@ -93,7 +91,8 @@ One can reverse a captured panic stack trace as follows:
 			}
 			files = append(files, file)
 		}
-		_, info, err := typecheck(files)
+		origImporter := importerForPkg(lpkg)
+		_, info, err := typecheck(lpkg.ImportPath, files, origImporter)
 		if err != nil {
 			return err
 		}

--- a/shared.go
+++ b/shared.go
@@ -383,15 +383,15 @@ var ErrNotFound = errors.New("not found")
 var ErrNotDependency = errors.New("not a dependency")
 
 // listPackage gets the listedPackage information for a certain package
-func listPackage(path string) (*listedPackage, error) {
-	if path == curPkg.ImportPath {
-		return curPkg, nil
+func listPackage(from *listedPackage, path string) (*listedPackage, error) {
+	if path == from.ImportPath {
+		return from, nil
 	}
 
 	// If the path is listed in the top-level ImportMap, use its mapping instead.
 	// This is a common scenario when dealing with vendored packages in GOROOT.
 	// The map is flat, so we don't need to recurse.
-	if path2 := curPkg.ImportMap[path]; path2 != "" {
+	if path2 := from.ImportMap[path]; path2 != "" {
 		path = path2
 	}
 
@@ -405,7 +405,7 @@ func listPackage(path string) (*listedPackage, error) {
 	//
 	// If ListedPackages lacks such a package we fill it via runtimeLinknamed.
 	// TODO: can we instead add runtimeLinknamed to the top-level "go list" args?
-	if curPkg.Standard {
+	if from.Standard {
 		if ok {
 			return pkg, nil
 		}
@@ -444,7 +444,7 @@ func listPackage(path string) (*listedPackage, error) {
 
 	// Packages outside std can list any package,
 	// as long as they depend on it directly or indirectly.
-	for _, dep := range curPkg.Deps {
+	for _, dep := range from.Deps {
 		if dep == pkg.ImportPath {
 			return pkg, nil
 		}

--- a/testdata/script/cache.txtar
+++ b/testdata/script/cache.txtar
@@ -17,12 +17,9 @@ rm garble-cache
 # level1c has the garble build cached with all files available.
 exec garble build ./level1c
 
-# TODO: this test now fails due to our fragile caching.
-! exec garble build
-stderr 'cannot load cache entry for test/main/level1b'
-# exec garble build
-# exec ./main
-# cmp stderr main.stderr
+exec garble build
+exec ./main
+cmp stderr main.stderr
 
 # verify with regular Go.
 go build


### PR DESCRIPTION
(see commit messages - please do not squash)

Fixes #708.