### PR TITLE
Check third party aws/aws-sdk-go-v2

### DIFF
--- a/scripts/cached_modfiles/github.com_aws_aws-sdk-go-v2_v1.18.1.mod
+++ b/scripts/cached_modfiles/github.com_aws_aws-sdk-go-v2_v1.18.1.mod
@@ -1,0 +1,9 @@
+module test
+
+go 1.20
+
+require (
+	github.com/aws/aws-sdk-go-v2 v1.18.1 // indirect
+	github.com/aws/smithy-go v1.13.5 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+)

--- a/scripts/cached_modfiles/github.com_aws_aws-sdk-go-v2_v1.18.1.sum
+++ b/scripts/cached_modfiles/github.com_aws_aws-sdk-go-v2_v1.18.1.sum
@@ -1,0 +1,13 @@
+github.com/aws/aws-sdk-go-v2 v1.18.1 h1:+tefE750oAb7ZQGzla6bLkOwfcQCEtC5y2RqoqCeqKo=
+github.com/aws/aws-sdk-go-v2 v1.18.1/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
+github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
+github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/scripts/check-third-party.sh
+++ b/scripts/check-third-party.sh
@@ -33,6 +33,8 @@ modules=(
 	github.com/andybalholm/brotli v1.0.4
 
 	# TODO: consider github.com/mattn/go-sqlite3 to cover a DB and more cgo
+
+	github.com/aws/aws-sdk-go-v2 v1.18.1
 )
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)


### PR DESCRIPTION
Adding `github.com/aws/aws-sdk-go-v2/` to third party checks

```
> go build -trimpath github.com/aws/aws-sdk-go-v2/...
> garble build github.com/aws/aws-sdk-go-v2/...
# github.com/aws/aws-sdk-go-v2/aws/protocol/xml
NQ6UGQOmEhWD.go:1: cannot convert npl77nD (variable of type noWrappedErrorResponse) to type QUcgoxINA
Y2yBn8.go:1: cannot convert npl77nD (variable of type wrappedErrorResponse) to type QUcgoxINA
exit status 2
exit status 1
> garble -tiny -literals build github.com/aws/aws-sdk-go-v2/...
# github.com/aws/aws-sdk-go-v2/aws/protocol/xml
:1: cannot convert zJSsYuZSMaNm (variable of type noWrappedErrorResponse) to type GtqPn7CdJn6
:1: cannot convert zJSsYuZSMaNm (variable of type wrappedErrorResponse) to type GtqPn7CdJn6
exit status 2
exit status 1
```