### PR TITLE
Include actual count of files with `CRLF` endings found

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@
 
 Andrew LeFevre <jalefevre@liberty.edu>
 Daniel Martí <mvdan@mvdan.cc>
+Emmanuel Chee-zaram Okeke <ecokeke21@gmail.com>
 Nicholas Jones <me@nicholasjon.es>
 Zachary Wasserman <zachwass2000@gmail.com>
 lu4p <lu4p@pm.me>

--- a/scripts/crlf-test.sh
+++ b/scripts/crlf-test.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
 
-if
-	grep \
-		--recursive \
-		--files-with-matches \
-		--binary \
-		--binary-files=without-match \
-		--max-count=1 \
-		--exclude-dir="\.git" \
-		$'\r' \
-		.
-then
-	# TODO exit status should be number of files with wrong endings found
-	echo -e "Found at least a file with CRLF endings."
-	exit 1
+file_count=$(grep \
+	--recursive \
+	--files-with-matches \
+	--binary \
+	--binary-files=without-match \
+	--max-count=1 \
+	--exclude-dir="\.git" \
+	$'\r' \
+	. | wc -l)
+
+if [[ $file_count -gt 0 ]]; then
+	echo -e "Found $file_count file(s) with CRLF endings."
+	exit "$file_count"
 fi
 
 echo -e "No files with CRLF endings found."


### PR DESCRIPTION
The script has been updated to include the actual count of files with CRLF endings found.
The exit status of the script now accurately reflects the number of files with incorrect line endings.

Explanation of changes:

- Added a variable `file_count` to store the count of files with wrong line endings.

- Modified the if condition to check if `$file_count` is greater than 0.

- Changed the output message to include the actual count of files found with CRLF endings.

- Modified the exit statement to use `$file_count` as the exit status.