### PR TITLE
report build settings with left alignment in version command

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ lu4p <lu4p@pm.me>
 pagran <pagran@protonmail.com>
 shellhazard <shellhazard@tutanota.com>
 xuannv <xuan11290@gmail.com>
+xieyuschen <xieyuschen@gmail.com>

--- a/main.go
+++ b/main.go
@@ -397,8 +397,8 @@ func mainErr(args []string) error {
 			//   veryverylong.key value
 			//          short.key some-other-value
 			//
-			// Empirically, 16 is enough; the longest key seen is "vcs.revision".
-			fmt.Printf("%16s %s\n", setting.Key, setting.Value)
+			// Empirically, 16 is enough; the longest key seen is "DefaultGODEBUG".
+			fmt.Printf("\t%-16s %s\n", setting.Key, setting.Value)
 		}
 		return nil
 	case "reverse":

--- a/testdata/script/help.txtar
+++ b/testdata/script/help.txtar
@@ -102,10 +102,10 @@ exec garble version
 stdout -count=1 'mvdan\.cc/garble v0\.0\.0-20220318134511-91ea24634954'
 stdout -count=1 'Build settings'
 stdout -count=3 '-compiler|GOOS|GOARCH'
-stdout -count=1 'vcs git'
-stdout -count=1 'vcs\.revision 91ea246349544769f5100c29f79cb0f173abfeea'
-stdout -count=1 'vcs\.time 2022-03-18T13:45:11Z'
-stdout -count=1 'vcs\.modified true'
+stdout -count=1 'vcs              git'
+stdout -count=1 'vcs\.revision     91ea246349544769f5100c29f79cb0f173abfeea'
+stdout -count=1 'vcs\.time         2022-03-18T13:45:11Z'
+stdout -count=1 'vcs\.modified     true'
 
 ! exec garble version -flag
 stderr 'usage: garble version'


### PR DESCRIPTION
Currently, 'garble version' uses right alignment to print its build setting. The alignment looks a bit messy especially when the key DefaultGODEBUG is long.

	mvdan.cc/garble v0.13.0

	Build settings:
	      -buildmode exe
	       -compiler gc
	  DefaultGODEBUG asynctimerchan=1,gotypesalias=0,httpservecontentkeepheaders=1,tls3des=1,tlskyber=0,x509keypairleaf=0,x509negativeserial=1
	     CGO_ENABLED 0
		  GOARCH arm64
		    GOOS darwin
		 GOARM64 v8.0

This PR tries to use left alignment to print all settings:

	mvdan.cc/garble v0.0.0-20241118082736-cd404dc74d49

	Build settings:
		-buildmode       exe
		-compiler        gc
		CGO_ENABLED      0
		GOARCH           arm64
		GOOS             darwin
		GOARM64          v8.0
		vcs              git
		vcs.revision     cd404dc74d496ee976e4f5e6907c7dc86fc3b205
		vcs.time         2024-11-18T08:27:36Z
		vcs.modified     false