### PR TITLE
rely on go/types alias tracking now that Go 1.23.5 is out

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,11 +63,12 @@ jobs:
       run: diff <(echo -n) <(gofmt -d .)
     - if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.23.x'
       run: go vet ./...
-    - if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.23.x'
-      uses: dominikh/staticcheck-action@v1
-      with:
-        version: "2024.1.1"
-        install-go: false
+    # TODO: staticcheck temporarily disabled as it was built with go1.23.4
+    # - if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.23.x'
+    #   uses: dominikh/staticcheck-action@v1
+    #   with:
+    #     version: "2024.1.1"
+    #     install-go: false
 
   # We don't care about GOARCH=386 particularly, hence -short,
   # but it helps ensure we support 32-bit hosts and targets well.

--- a/bench_test.go
+++ b/bench_test.go
@@ -117,7 +117,7 @@ func BenchmarkBuild(b *testing.B) {
 			// The cached rebuild will reuse all dependencies,
 			// but rebuild the main package itself.
 			if cached {
-				writeSourceFile("rebuild.go", []byte(fmt.Sprintf("package main\nvar v%d int", i)))
+				writeSourceFile("rebuild.go", fmt.Appendf(nil, "package main\nvar v%d int", i))
 			}
 
 			cmd := exec.Command(os.Args[0], args...)

--- a/bundled_typeparams.go
+++ b/bundled_typeparams.go
@@ -1,0 +1,354 @@
+// Originally bundled from golang.org/x/tools/internal/typeparams@v0.29.0,
+// as it is used by x/tools/go/types/typeutil and is an internal package.
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"go/types"
+)
+
+var errEmptyTypeSet = errors.New("empty type set")
+
+// InterfaceTermSet computes the normalized terms for a constraint interface,
+// returning an error if the term set cannot be computed or is empty. In the
+// latter case, the error will be ErrEmptyTypeSet.
+//
+// See the documentation of StructuralTerms for more information on
+// normalization.
+func typeparams_InterfaceTermSet(iface *types.Interface) ([]*types.Term, error) {
+	return typeparams_computeTermSet(iface)
+}
+
+// UnionTermSet computes the normalized terms for a union, returning an error
+// if the term set cannot be computed or is empty. In the latter case, the
+// error will be ErrEmptyTypeSet.
+//
+// See the documentation of StructuralTerms for more information on
+// normalization.
+func typeparams_UnionTermSet(union *types.Union) ([]*types.Term, error) {
+	return typeparams_computeTermSet(union)
+}
+
+func typeparams_computeTermSet(typ types.Type) ([]*types.Term, error) {
+	tset, err := typeparams_computeTermSetInternal(typ, make(map[types.Type]*typeparams_termSet), 0)
+	if err != nil {
+		return nil, err
+	}
+	if tset.terms.isEmpty() {
+		return nil, errEmptyTypeSet
+	}
+	if tset.terms.isAll() {
+		return nil, nil
+	}
+	var terms []*types.Term
+	for _, term := range tset.terms {
+		terms = append(terms, types.NewTerm(term.tilde, term.typ))
+	}
+	return terms, nil
+}
+
+// A termSet holds the normalized set of terms for a given type.
+//
+// The name termSet is intentionally distinct from 'type set': a type set is
+// all types that implement a type (and includes method restrictions), whereas
+// a term set just represents the structural restrictions on a type.
+type typeparams_termSet struct {
+	complete bool
+	terms    typeparams_termlist
+}
+
+func typeparams_computeTermSetInternal(t types.Type, seen map[types.Type]*typeparams_termSet, depth int) (res *typeparams_termSet, err error) {
+	if t == nil {
+		panic("nil type")
+	}
+
+	const maxTermCount = 100
+	if tset, ok := seen[t]; ok {
+		if !tset.complete {
+			return nil, fmt.Errorf("cycle detected in the declaration of %s", t)
+		}
+		return tset, nil
+	}
+
+	// Mark the current type as seen to avoid infinite recursion.
+	tset := new(typeparams_termSet)
+	defer func() {
+		tset.complete = true
+	}()
+	seen[t] = tset
+
+	switch u := t.Underlying().(type) {
+	case *types.Interface:
+		// The term set of an interface is the intersection of the term sets of its
+		// embedded types.
+		tset.terms = typeparams_allTermlist
+		for i := 0; i < u.NumEmbeddeds(); i++ {
+			embedded := u.EmbeddedType(i)
+			if _, ok := embedded.Underlying().(*types.TypeParam); ok {
+				return nil, fmt.Errorf("invalid embedded type %T", embedded)
+			}
+			tset2, err := typeparams_computeTermSetInternal(embedded, seen, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			tset.terms = tset.terms.intersect(tset2.terms)
+		}
+	case *types.Union:
+		// The term set of a union is the union of term sets of its terms.
+		tset.terms = nil
+		for i := 0; i < u.Len(); i++ {
+			t := u.Term(i)
+			var terms typeparams_termlist
+			switch t.Type().Underlying().(type) {
+			case *types.Interface:
+				tset2, err := typeparams_computeTermSetInternal(t.Type(), seen, depth+1)
+				if err != nil {
+					return nil, err
+				}
+				terms = tset2.terms
+			case *types.TypeParam, *types.Union:
+				// A stand-alone type parameter or union is not permitted as union
+				// term.
+				return nil, fmt.Errorf("invalid union term %T", t)
+			default:
+				if t.Type() == types.Typ[types.Invalid] {
+					continue
+				}
+				terms = typeparams_termlist{{t.Tilde(), t.Type()}}
+			}
+			tset.terms = tset.terms.union(terms)
+			if len(tset.terms) > maxTermCount {
+				return nil, fmt.Errorf("exceeded max term count %d", maxTermCount)
+			}
+		}
+	case *types.TypeParam:
+		panic("unreachable")
+	default:
+		// For all other types, the term set is just a single non-tilde term
+		// holding the type itself.
+		if u != types.Typ[types.Invalid] {
+			tset.terms = typeparams_termlist{{false, t}}
+		}
+	}
+	return tset, nil
+}
+
+// under is a facade for the go/types internal function of the same name. It is
+// used by typeterm.go.
+func typeparams_under(t types.Type) types.Type {
+	return t.Underlying()
+}
+
+// A termlist represents the type set represented by the union
+// t1 ∪ y2 ∪ ... tn of the type sets of the terms t1 to tn.
+// A termlist is in normal form if all terms are disjoint.
+// termlist operations don't require the operands to be in
+// normal form.
+type typeparams_termlist []*typeparams_term
+
+// allTermlist represents the set of all types.
+// It is in normal form.
+
+// allTermlist represents the set of all types.
+// It is in normal form.
+var typeparams_allTermlist = typeparams_termlist{new(typeparams_term)}
+
+// String prints the termlist exactly (without normalization).
+func (xl typeparams_termlist) String() string {
+	if len(xl) == 0 {
+		return "∅"
+	}
+	var buf bytes.Buffer
+	for i, x := range xl {
+		if i > 0 {
+			buf.WriteString(" | ")
+		}
+		buf.WriteString(x.String())
+	}
+	return buf.String()
+}
+
+// isEmpty reports whether the termlist xl represents the empty set of types.
+func (xl typeparams_termlist) isEmpty() bool {
+	// If there's a non-nil term, the entire list is not empty.
+	// If the termlist is in normal form, this requires at most
+	// one iteration.
+	for _, x := range xl {
+		if x != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// isAll reports whether the termlist xl represents the set of all types.
+func (xl typeparams_termlist) isAll() bool {
+	// If there's a 𝓤 term, the entire list is 𝓤.
+	// If the termlist is in normal form, this requires at most
+	// one iteration.
+	for _, x := range xl {
+		if x != nil && x.typ == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// norm returns the normal form of xl.
+func (xl typeparams_termlist) norm() typeparams_termlist {
+	// Quadratic algorithm, but good enough for now.
+	// TODO(gri) fix asymptotic performance
+	used := make([]bool, len(xl))
+	var rl typeparams_termlist
+	for i, xi := range xl {
+		if xi == nil || used[i] {
+			continue
+		}
+		for j := i + 1; j < len(xl); j++ {
+			xj := xl[j]
+			if xj == nil || used[j] {
+				continue
+			}
+			if u1, u2 := xi.union(xj); u2 == nil {
+				// If we encounter a 𝓤 term, the entire list is 𝓤.
+				// Exit early.
+				// (Note that this is not just an optimization;
+				// if we continue, we may end up with a 𝓤 term
+				// and other terms and the result would not be
+				// in normal form.)
+				if u1.typ == nil {
+					return typeparams_allTermlist
+				}
+				xi = u1
+				used[j] = true // xj is now unioned into xi - ignore it in future iterations
+			}
+		}
+		rl = append(rl, xi)
+	}
+	return rl
+}
+
+// union returns the union xl ∪ yl.
+func (xl typeparams_termlist) union(yl typeparams_termlist) typeparams_termlist {
+	return append(xl, yl...).norm()
+}
+
+// intersect returns the intersection xl ∩ yl.
+func (xl typeparams_termlist) intersect(yl typeparams_termlist) typeparams_termlist {
+	if xl.isEmpty() || yl.isEmpty() {
+		return nil
+	}
+
+	// Quadratic algorithm, but good enough for now.
+	// TODO(gri) fix asymptotic performance
+	var rl typeparams_termlist
+	for _, x := range xl {
+		for _, y := range yl {
+			if r := x.intersect(y); r != nil {
+				rl = append(rl, r)
+			}
+		}
+	}
+	return rl.norm()
+}
+
+// A term describes elementary type sets:
+//
+//	 ∅:  (*term)(nil)     == ∅                      // set of no types (empty set)
+//	 𝓤:  &term{}          == 𝓤                      // set of all types (𝓤niverse)
+//	 T:  &term{false, T}  == {T}                    // set of type T
+//	~t:  &term{true, t}   == {t' | under(t') == t}  // set of types with underlying type t
+type typeparams_term struct {
+	tilde bool // valid if typ != nil
+	typ   types.Type
+}
+
+func (x *typeparams_term) String() string {
+	switch {
+	case x == nil:
+		return "∅"
+	case x.typ == nil:
+		return "𝓤"
+	case x.tilde:
+		return "~" + x.typ.String()
+	default:
+		return x.typ.String()
+	}
+}
+
+// union returns the union x ∪ y: zero, one, or two non-nil terms.
+func (x *typeparams_term) union(y *typeparams_term) (_, _ *typeparams_term) {
+	// easy cases
+	switch {
+	case x == nil && y == nil:
+		return nil, nil // ∅ ∪ ∅ == ∅
+	case x == nil:
+		return y, nil // ∅ ∪ y == y
+	case y == nil:
+		return x, nil // x ∪ ∅ == x
+	case x.typ == nil:
+		return x, nil // 𝓤 ∪ y == 𝓤
+	case y.typ == nil:
+		return y, nil // x ∪ 𝓤 == 𝓤
+	}
+	// ∅ ⊂ x, y ⊂ 𝓤
+
+	if x.disjoint(y) {
+		return x, y // x ∪ y == (x, y) if x ∩ y == ∅
+	}
+	// x.typ == y.typ
+
+	// ~t ∪ ~t == ~t
+	// ~t ∪  T == ~t
+	//  T ∪ ~t == ~t
+	//  T ∪  T ==  T
+	if x.tilde || !y.tilde {
+		return x, nil
+	}
+	return y, nil
+}
+
+// intersect returns the intersection x ∩ y.
+func (x *typeparams_term) intersect(y *typeparams_term) *typeparams_term {
+	// easy cases
+	switch {
+	case x == nil || y == nil:
+		return nil // ∅ ∩ y == ∅ and ∩ ∅ == ∅
+	case x.typ == nil:
+		return y // 𝓤 ∩ y == y
+	case y.typ == nil:
+		return x // x ∩ 𝓤 == x
+	}
+	// ∅ ⊂ x, y ⊂ 𝓤
+
+	if x.disjoint(y) {
+		return nil // x ∩ y == ∅ if x ∩ y == ∅
+	}
+	// x.typ == y.typ
+
+	// ~t ∩ ~t == ~t
+	// ~t ∩  T ==  T
+	//  T ∩ ~t ==  T
+	//  T ∩  T ==  T
+	if !x.tilde || y.tilde {
+		return x
+	}
+	return y
+}
+
+// disjoint reports whether x ∩ y == ∅.
+// x.typ and y.typ must not be nil.
+func (x *typeparams_term) disjoint(y *typeparams_term) bool {
+	ux := x.typ
+	if y.tilde {
+		ux = typeparams_under(ux)
+	}
+	uy := y.typ
+	if x.tilde {
+		uy = typeparams_under(uy)
+	}
+	return !types.Identical(ux, uy)
+}

--- a/bundled_typeutil.go
+++ b/bundled_typeutil.go
@@ -1,0 +1,295 @@
+// Originally bundled from golang.org/x/tools/go/types/typeutil@v0.29.0.
+// Edited to just keep the hasher API in place, removing the use of internal/typeparams,
+// and removed the inclusion of struct field tags in the hasher.
+
+package main
+
+import (
+	"fmt"
+	"go/types"
+)
+
+// -- Hasher --
+
+// hash returns the hash of type t.
+// TODO(adonovan): replace by types.Hash when Go proposal #69420 is accepted.
+func typeutil_hash(t types.Type) uint32 {
+	return typeutil_theHasher.Hash(t)
+}
+
+// A Hasher provides a [Hasher.Hash] method to map a type to its hash value.
+// Hashers are stateless, and all are equivalent.
+type typeutil_Hasher struct{}
+
+var typeutil_theHasher typeutil_Hasher
+
+// Hash computes a hash value for the given type t such that
+// Identical(t, t') => Hash(t) == Hash(t').
+func (h typeutil_Hasher) Hash(t types.Type) uint32 {
+	return typeutil_hasher{inGenericSig: false}.hash(t)
+}
+
+// hasher holds the state of a single Hash traversal: whether we are
+// inside the signature of a generic function; this is used to
+// optimize [hasher.hashTypeParam].
+type typeutil_hasher struct{ inGenericSig bool }
+
+// hashString computes the Fowler–Noll–Vo hash of s.
+func typeutil_hashString(s string) uint32 {
+	var h uint32
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= 16777619
+	}
+	return h
+}
+
+// hash computes the hash of t.
+func (h typeutil_hasher) hash(t types.Type) uint32 {
+	// See Identical for rationale.
+	switch t := t.(type) {
+	case *types.Basic:
+		return uint32(t.Kind())
+
+	case *types.Alias:
+		return h.hash(types.Unalias(t))
+
+	case *types.Array:
+		return 9043 + 2*uint32(t.Len()) + 3*h.hash(t.Elem())
+
+	case *types.Slice:
+		return 9049 + 2*h.hash(t.Elem())
+
+	case *types.Struct:
+		var hash uint32 = 9059
+		for i, n := 0, t.NumFields(); i < n; i++ {
+			f := t.Field(i)
+			if f.Anonymous() {
+				hash += 8861
+			}
+			// NOTE: we must not hash struct field tags, as they do not affect type identity.
+			// hash += typeutil_hashString(t.Tag(i))
+			hash += typeutil_hashString(f.Name()) // (ignore f.Pkg)
+			hash += h.hash(f.Type())
+		}
+		return hash
+
+	case *types.Pointer:
+		return 9067 + 2*h.hash(t.Elem())
+
+	case *types.Signature:
+		var hash uint32 = 9091
+		if t.Variadic() {
+			hash *= 8863
+		}
+
+		tparams := t.TypeParams()
+		for i := range tparams.Len() {
+			h.inGenericSig = true
+			tparam := tparams.At(i)
+			hash += 7 * h.hash(tparam.Constraint())
+		}
+
+		return hash + 3*h.hashTuple(t.Params()) + 5*h.hashTuple(t.Results())
+
+	case *types.Union:
+		return h.hashUnion(t)
+
+	case *types.Interface:
+		// Interfaces are identical if they have the same set of methods, with
+		// identical names and types, and they have the same set of type
+		// restrictions. See go/types.identical for more details.
+		var hash uint32 = 9103
+
+		// Hash methods.
+		for i, n := 0, t.NumMethods(); i < n; i++ {
+			// Method order is not significant.
+			// Ignore m.Pkg().
+			m := t.Method(i)
+			// Use shallow hash on method signature to
+			// avoid anonymous interface cycles.
+			hash += 3*typeutil_hashString(m.Name()) + 5*h.shallowHash(m.Type())
+		}
+
+		// Hash type restrictions.
+		terms, err := typeparams_InterfaceTermSet(t)
+		// if err != nil t has invalid type restrictions.
+		if err == nil {
+			hash += h.hashTermSet(terms)
+		}
+
+		return hash
+
+	case *types.Map:
+		return 9109 + 2*h.hash(t.Key()) + 3*h.hash(t.Elem())
+
+	case *types.Chan:
+		return 9127 + 2*uint32(t.Dir()) + 3*h.hash(t.Elem())
+
+	case *types.Named:
+		hash := h.hashTypeName(t.Obj())
+		targs := t.TypeArgs()
+		for i := 0; i < targs.Len(); i++ {
+			targ := targs.At(i)
+			hash += 2 * h.hash(targ)
+		}
+		return hash
+
+	case *types.TypeParam:
+		return h.hashTypeParam(t)
+
+	case *types.Tuple:
+		return h.hashTuple(t)
+	}
+
+	panic(fmt.Sprintf("%T: %v", t, t))
+}
+
+func (h typeutil_hasher) hashTuple(tuple *types.Tuple) uint32 {
+	// See go/types.identicalTypes for rationale.
+	n := tuple.Len()
+	hash := 9137 + 2*uint32(n)
+	for i := range n {
+		hash += 3 * h.hash(tuple.At(i).Type())
+	}
+	return hash
+}
+
+func (h typeutil_hasher) hashUnion(t *types.Union) uint32 {
+	// Hash type restrictions.
+	terms, err := typeparams_UnionTermSet(t)
+	// if err != nil t has invalid type restrictions. Fall back on a non-zero
+	// hash.
+	if err != nil {
+		return 9151
+	}
+	return h.hashTermSet(terms)
+}
+
+func (h typeutil_hasher) hashTermSet(terms []*types.Term) uint32 {
+	hash := 9157 + 2*uint32(len(terms))
+	for _, term := range terms {
+		// term order is not significant.
+		termHash := h.hash(term.Type())
+		if term.Tilde() {
+			termHash *= 9161
+		}
+		hash += 3 * termHash
+	}
+	return hash
+}
+
+// hashTypeParam returns the hash of a type parameter.
+func (h typeutil_hasher) hashTypeParam(t *types.TypeParam) uint32 {
+	// Within the signature of a generic function, TypeParams are
+	// identical if they have the same index and constraint, so we
+	// hash them based on index.
+	//
+	// When we are outside a generic function, free TypeParams are
+	// identical iff they are the same object, so we can use a
+	// more discriminating hash consistent with object identity.
+	// This optimization saves [Map] about 4% when hashing all the
+	// types.Info.Types in the forward closure of net/http.
+	if !h.inGenericSig {
+		// Optimization: outside a generic function signature,
+		// use a more discrimating hash consistent with object identity.
+		return h.hashTypeName(t.Obj())
+	}
+	return 9173 + 3*uint32(t.Index())
+}
+
+// hashTypeName hashes the pointer of tname.
+func (typeutil_hasher) hashTypeName(tname *types.TypeName) uint32 {
+	// NOTE: we must not hash any pointers, as garble is a toolexec tool
+	// so by nature it uses multiple processes.
+	return typeutil_hashString(tname.Name())
+	// Since types.Identical uses == to compare TypeNames,
+	// the Hash function uses maphash.Comparable.
+	// TODO(adonovan): or will, when it becomes available in go1.24.
+	// In the meantime we use the pointer's numeric value.
+	//
+	//   hash := maphash.Comparable(theSeed, tname)
+	//
+	// (Another approach would be to hash the name and package
+	// path, and whether or not it is a package-level typename. It
+	// is rare for a package to define multiple local types with
+	// the same name.)
+	// hash := uintptr(unsafe.Pointer(tname))
+	// return uint32(hash ^ (hash >> 32))
+}
+
+// shallowHash computes a hash of t without looking at any of its
+// element Types, to avoid potential anonymous cycles in the types of
+// interface methods.
+//
+// When an unnamed non-empty interface type appears anywhere among the
+// arguments or results of an interface method, there is a potential
+// for endless recursion. Consider:
+//
+//	type X interface { m() []*interface { X } }
+//
+// The problem is that the Methods of the interface in m's result type
+// include m itself; there is no mention of the named type X that
+// might help us break the cycle.
+// (See comment in go/types.identical, case *Interface, for more.)
+func (h typeutil_hasher) shallowHash(t types.Type) uint32 {
+	// t is the type of an interface method (Signature),
+	// its params or results (Tuples), or their immediate
+	// elements (mostly Slice, Pointer, Basic, Named),
+	// so there's no need to optimize anything else.
+	switch t := t.(type) {
+	case *types.Alias:
+		return h.shallowHash(types.Unalias(t))
+
+	case *types.Signature:
+		var hash uint32 = 604171
+		if t.Variadic() {
+			hash *= 971767
+		}
+		// The Signature/Tuple recursion is always finite
+		// and invariably shallow.
+		return hash + 1062599*h.shallowHash(t.Params()) + 1282529*h.shallowHash(t.Results())
+
+	case *types.Tuple:
+		n := t.Len()
+		hash := 9137 + 2*uint32(n)
+		for i := range n {
+			hash += 53471161 * h.shallowHash(t.At(i).Type())
+		}
+		return hash
+
+	case *types.Basic:
+		return 45212177 * uint32(t.Kind())
+
+	case *types.Array:
+		return 1524181 + 2*uint32(t.Len())
+
+	case *types.Slice:
+		return 2690201
+
+	case *types.Struct:
+		return 3326489
+
+	case *types.Pointer:
+		return 4393139
+
+	case *types.Union:
+		return 562448657
+
+	case *types.Interface:
+		return 2124679 // no recursion here
+
+	case *types.Map:
+		return 9109
+
+	case *types.Chan:
+		return 9127
+
+	case *types.Named:
+		return h.hashTypeName(t.Obj())
+
+	case *types.TypeParam:
+		return h.hashTypeParam(t)
+	}
+	panic(fmt.Sprintf("shallowHash: %T: %v", t, t))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module mvdan.cc/garble
 
-go 1.23
+// Before the .5 bugfix release, alias tracking via go/types
+// was broken; see https://go.dev/issue/70517.
+go 1.23.5
 
 require (
 	github.com/bluekeyes/go-gitdiff v0.8.0

--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,12 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/rogpeppe/go-internal v1.13.2-0.20241226121412-a5dc8ff20d0a
 	golang.org/x/mod v0.22.0
-	golang.org/x/tools v0.27.0
+	golang.org/x/tools v0.29.0
 )
 
 require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	golang.org/x/sync v0.9.0 // indirect
-	golang.org/x/sys v0.27.0 // indirect
+	golang.org/x/sync v0.10.0 // indirect
+	golang.org/x/sys v0.29.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,9 +15,9 @@ github.com/rogpeppe/go-internal v1.13.2-0.20241226121412-a5dc8ff20d0a h1:w3tdWGK
 github.com/rogpeppe/go-internal v1.13.2-0.20241226121412-a5dc8ff20d0a/go.mod h1:S8kfXMp+yh77OxPD4fdM6YUknrZpQxLhvxzS4gDHENY=
 golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
 golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
-golang.org/x/sync v0.9.0 h1:fEo0HyrW1GIgZdpbhCRO0PkJajUS5H9IFUztCgEo2jQ=
-golang.org/x/sync v0.9.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
-golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/tools v0.27.0 h1:qEKojBykQkQ4EynWy4S8Weg69NumxKdn40Fce3uc/8o=
-golang.org/x/tools v0.27.0/go.mod h1:sUi0ZgbwW9ZPAq26Ekut+weQPR5eIM6GQLQ1Yjm1H0Q=
+golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
+golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
+golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/tools v0.29.0 h1:Xx0h3TtM9rzQpQuR4dKLrdglAmCEN5Oi+P74JdhdzXE=
+golang.org/x/tools v0.29.0/go.mod h1:KMQVMRsVxU6nHCFXrBPhDB8XncLNLM0lIy/F14RP588=

--- a/internal/ctrlflow/ssa.go
+++ b/internal/ctrlflow/ssa.go
@@ -11,7 +11,7 @@ import (
 
 // setUnexportedField is used to modify unexported fields of ssa api structures.
 // TODO: find an alternative way to access private fields or raise a feature request upstream
-func setUnexportedField(objRaw interface{}, name string, valRaw interface{}) {
+func setUnexportedField(objRaw any, name string, valRaw any) {
 	obj := reflect.ValueOf(objRaw)
 	for obj.Kind() == reflect.Pointer || obj.Kind() == reflect.Interface {
 		obj = obj.Elem()

--- a/internal/linker/linker.go
+++ b/internal/linker/linker.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"go/version"
 	"io"
 	"io/fs"
 	"os"
@@ -211,11 +212,7 @@ func buildLinker(workingDir string, overlay map[string]string, outputLinkPath st
 }
 
 func PatchLinker(goRoot, goVersion, cacheDir, tempDir string) (string, func(), error) {
-	// rxVersion looks for a version like "go1.19" or "go1.20"
-	rxVersion := regexp.MustCompile(`go\d+\.\d+`)
-	majorGoVersion := rxVersion.FindString(goVersion)
-
-	patchesVer, modFiles, patches, err := loadLinkerPatches(majorGoVersion)
+	patchesVer, modFiles, patches, err := loadLinkerPatches(version.Lang(goVersion))
 	if err != nil {
 		return "", nil, fmt.Errorf("cannot retrieve linker patches: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -151,7 +151,6 @@ var (
 	fset = token.NewFileSet()
 
 	sharedTempDir = os.Getenv("GARBLE_SHARED")
-	parentWorkDir = os.Getenv("GARBLE_PARENT_WORK")
 )
 
 const actionGraphFileName = "action-graph.json"
@@ -601,15 +600,11 @@ This command wraps "go %s". Below is its help:
 		return nil, err
 	}
 	os.Setenv("GARBLE_SHARED", sharedTempDir)
-	wd, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-	os.Setenv("GARBLE_PARENT_WORK", wd)
 
 	if flagDebugDir != "" {
-		if !filepath.IsAbs(flagDebugDir) {
-			flagDebugDir = filepath.Join(wd, flagDebugDir)
+		flagDebugDir, err = filepath.Abs(flagDebugDir)
+		if err != nil {
+			return nil, err
 		}
 
 		if err := os.RemoveAll(flagDebugDir); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -42,6 +42,7 @@ func TestMain(m *testing.M) {
 	}
 	if os.Getenv("RUN_GARBLE_MAIN") == "true" {
 		main()
+		return
 	}
 	testscript.Main(garbleMain{m}, map[string]func(){
 		"garble": main,

--- a/scripts/bench_literals.go
+++ b/scripts/bench_literals.go
@@ -39,7 +39,7 @@ func generateRunSrc() string {
 	sb.WriteString(`
 var alwaysFalseFlag = false
 
-func noop(i interface{}) {
+func noop(i any) {
 	if alwaysFalseFlag {
 		println(i)
 	}	

--- a/testdata/script/goversion.txtar
+++ b/testdata/script/goversion.txtar
@@ -7,13 +7,13 @@ env PATH=${WORK}/.bin${:}${PATH}
 # An empty go version.
 env TOOLCHAIN_GOVERSION=''
 ! exec garble build
-stderr 'Go version is too old; please upgrade to go1\.23 or newer'
+stderr 'Go version is too old; please upgrade to go1\.23\.5 or newer'
 
 # We should error on a devel version that's too old.
 # Note that they lacked the "goN.M-" prefix.
 env TOOLCHAIN_GOVERSION='devel +afb5fca Sun Aug 07 00:00:00 2020 +0000'
 ! exec garble build
-stderr 'Go version is too old; please upgrade to go1\.23 or newer'
+stderr 'Go version is too old; please upgrade to go1\.23\.5 or newer'
 
 # Another form of old version; with an old "goN.M-" prefix.
 env TOOLCHAIN_GOVERSION='devel go1.15-afb5fca Sun Aug 07 00:00:00 2020 +0000'
@@ -22,15 +22,16 @@ stderr 'Go version "devel go1\.15-.*2020.*" is too old; please upgrade to go1\.2
 
 # A current devel version should be fine.
 # Note that we don't look at devel version timestamps.
-env GARBLE_TEST_GOVERSION='go1.23.0'
-env TOOLCHAIN_GOVERSION='devel go1.23-ad97d204f0 Sun Sep 12 16:46:58 2023 +0000'
-! exec garble build
-stderr 'mocking the real build'
+env GARBLE_TEST_GOVERSION='go1.23.5'
+# TODO: temporarily disabled while we do not support tip.
+# env TOOLCHAIN_GOVERSION='devel go1.23-ad97d204f0 Sun Sep 12 16:46:58 2023 +0000'
+# ! exec garble build
+# stderr 'mocking the real build'
 
 # We should error on a stable version that's too old.
 env TOOLCHAIN_GOVERSION='go1.14'
 ! exec garble build
-stderr 'Go version "go1\.14" is too old; please upgrade to go1\.23 or newer'
+stderr 'Go version "go1\.14" is too old; please upgrade to go1\.23\.5 or newer'
 
 # We should reject a future stable version, as we don't have linker patches yet.
 # Note that we need to bump the version of Go that supposedly built it, too.
@@ -40,27 +41,27 @@ env TOOLCHAIN_GOVERSION='go1.28.2'
 stderr 'Go version "go1\.28\.2" is too new; Go linker patches aren''t available for go1\.24 or later yet'
 
 # We should accept custom devel strings.
-env TOOLCHAIN_GOVERSION='devel go1.23-somecustomversion'
+env TOOLCHAIN_GOVERSION='devel go1.23.5-somecustomversion'
 ! exec garble build
 stderr 'mocking the real build'
 
 # The current toolchain may be older than the one that built garble.
-env GARBLE_TEST_GOVERSION='go1.23.2'
-env TOOLCHAIN_GOVERSION='go1.23.1'
+env GARBLE_TEST_GOVERSION='go1.23.22'
+env TOOLCHAIN_GOVERSION='go1.23.21'
 ! exec garble build
 stderr 'mocking the real build'
 
 # The current toolchain may be equal to the one that built garble.
-env GARBLE_TEST_GOVERSION='devel go1.23-6673d5d701 Sun Mar 20 16:05:03 2023 +0000'
-env TOOLCHAIN_GOVERSION='devel go1.23-6673d5d701 Sun Mar 20 16:05:03 2023 +0000'
+env GARBLE_TEST_GOVERSION='go1.23.25'
+env TOOLCHAIN_GOVERSION='go1.23.25'
 ! exec garble build
 stderr 'mocking the real build'
 
 # The current toolchain must not be newer than the one that built garble.
 env GARBLE_TEST_GOVERSION='go1.18'
-env TOOLCHAIN_GOVERSION='go1.23.1'
+env TOOLCHAIN_GOVERSION='go1.23.25'
 ! exec garble build
-stderr 'garble was built with "go1\.18" and can''t be used with the newer "go1\.23\.1"; rebuild '
+stderr 'garble was built with "go1\.18" and can''t be used with the newer "go1\.23\.25"; rebuild '
 
 # We'll error even if the difference is a minor (bugfix) level.
 # In practice it probably wouldn't matter, but in theory it could still lead to tricky bugs.
@@ -72,7 +73,7 @@ stderr 'garble was built with "go1\.23\.11" and can''t be used with the newer "g
 # If garble builds itself and is then used, it won't know what version built it.
 # As a fallback, we drop the comparison against the toolchain's version.
 env GARBLE_TEST_GOVERSION='bogus version'
-env TOOLCHAIN_GOVERSION='go1.23.3'
+env TOOLCHAIN_GOVERSION='go1.23.25'
 ! exec garble build
 stderr 'mocking the real build'
 -- go.mod --

--- a/testdata/script/implement.txtar
+++ b/testdata/script/implement.txtar
@@ -1,4 +1,5 @@
-exec garble build
+go build
+exec garble -debugdir=/tmp/test build
 exec ./main
 cmp stdout main.stdout
 
@@ -45,12 +46,15 @@ var _ privateInterface = T("")
 
 type StructUnnamed = struct {
 	Foo int
-	Bar struct {
+	Bar []*struct {
 		Nested *[]string
+		NestedTagged string
+		NestedAlias int64 // we can skip the alias too
 	}
 	Named lib3.Named
 	lib3.StructEmbed
 	Tagged string // no field tag
+	Alias int64   // we can skip the alias too
 }
 
 var _ = lib1.Struct1(lib2.Struct2{})
@@ -83,13 +87,18 @@ import "test/main/lib3"
 
 type Struct1 struct {
 	Foo int
-	Bar struct {
+	Bar []*struct {
 		Nested *[]string
+		NestedTagged string `json:"tagged1"`
+		NestedAlias alias1
 	}
 	Named lib3.Named
 	lib3.StructEmbed
 	Tagged string `json:"tagged1"`
+	Alias alias1
 }
+
+type alias1 = int64
 
 -- lib2/lib2.go --
 package lib2
@@ -98,13 +107,18 @@ import "test/main/lib3"
 
 type Struct2 struct {
 	Foo int
-	Bar struct {
+	Bar []*struct {
 		Nested *[]string
+		NestedTagged string `json:"tagged2"`
+		NestedAlias alias2
 	}
 	Named lib3.Named
 	lib3.StructEmbed
 	Tagged string `json:"tagged2"`
+	Alias alias2
 }
+
+type alias2 = int64
 -- lib3/lib3.go --
 package lib3
 


### PR DESCRIPTION
(see commit messages - please do not squash)

Fixes #827.