### PR TITLE
String pattern mitigation

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -12,6 +12,7 @@ import (
 	"go/token"
 	"go/types"
 	"io"
+	mathrand "math/rand"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -309,6 +310,15 @@ const (
 	// which is nameBase64.DecodedLen(12) being rounded up.
 	neededSumBytes = 9
 )
+
+// randomName generates a random name derived from the given baseName, using the provided random source.
+func randomName(rand *mathrand.Rand, baseName string) string {
+	salt := make([]byte, buildIDHashLength)
+	if _, err := rand.Read(salt); err != nil {
+		panic(err)
+	}
+	return hashWithCustomSalt(salt, baseName)
+}
 
 // hashWithCustomSalt returns a hashed version of name,
 // including the provided salt as well as opts.Seed into the hash input.

--- a/internal/asthelper/asthelper.go
+++ b/internal/asthelper/asthelper.go
@@ -43,24 +43,8 @@ func CallExpr(fun ast.Expr, args ...ast.Expr) *ast.CallExpr {
 	}
 }
 
-// LambdaCall "func() resultType {block}()"
-func LambdaCall(resultType ast.Expr, block *ast.BlockStmt) *ast.CallExpr {
-	funcLit := &ast.FuncLit{
-		Type: &ast.FuncType{
-			Params: &ast.FieldList{},
-			Results: &ast.FieldList{
-				List: []*ast.Field{
-					{Type: resultType},
-				},
-			},
-		},
-		Body: block,
-	}
-	return CallExpr(funcLit)
-}
-
-// LambdaCallParams "func(params) resultType {block}(args)"
-func LambdaCallParams(params *ast.FieldList, resultType ast.Expr, block *ast.BlockStmt, args []ast.Expr) *ast.CallExpr {
+// LambdaCall "func(params) resultType {block}(args)"
+func LambdaCall(params *ast.FieldList, resultType ast.Expr, block *ast.BlockStmt, args []ast.Expr) *ast.CallExpr {
 	funcLit := &ast.FuncLit{
 		Type: &ast.FuncType{
 			Params: params,

--- a/internal/asthelper/asthelper.go
+++ b/internal/asthelper/asthelper.go
@@ -59,6 +59,22 @@ func LambdaCall(resultType ast.Expr, block *ast.BlockStmt) *ast.CallExpr {
 	return CallExpr(funcLit)
 }
 
+// LambdaCallParams "func(params) resultType {block}(args)"
+func LambdaCallParams(params *ast.FieldList, resultType ast.Expr, block *ast.BlockStmt, args []ast.Expr) *ast.CallExpr {
+	funcLit := &ast.FuncLit{
+		Type: &ast.FuncType{
+			Params: params,
+			Results: &ast.FieldList{
+				List: []*ast.Field{
+					{Type: resultType},
+				},
+			},
+		},
+		Body: block,
+	}
+	return CallExpr(funcLit, args...)
+}
+
 // ReturnStmt "return result"
 func ReturnStmt(results ...ast.Expr) *ast.ReturnStmt {
 	return &ast.ReturnStmt{

--- a/internal/asthelper/asthelper.go
+++ b/internal/asthelper/asthelper.go
@@ -140,6 +140,63 @@ func IndexExprByExpr(xExpr, indexExpr ast.Expr) *ast.IndexExpr {
 	return &ast.IndexExpr{X: xExpr, Index: indexExpr}
 }
 
+// UnaryExpr creates a unary expression with the given operator and operand
+func UnaryExpr(op token.Token, x ast.Expr) *ast.UnaryExpr {
+	return &ast.UnaryExpr{
+		Op: op,
+		X:  x,
+	}
+}
+
+// StarExpr creates a pointer type expression "*x"
+func StarExpr(x ast.Expr) *ast.StarExpr {
+	return &ast.StarExpr{X: x}
+}
+
+// ArrayType creates an array type expression "[len]eltType"
+func ArrayType(len ast.Expr, eltType ast.Expr) *ast.ArrayType {
+	return &ast.ArrayType{
+		Len: len,
+		Elt: eltType,
+	}
+}
+
+// ByteArrayType creates a byte array type "[len]byte"
+func ByteArrayType(len int64) *ast.ArrayType {
+	lenLit := IntLit(int(len))
+	return ArrayType(lenLit, ast.NewIdent("byte"))
+}
+
+// ByteSliceType creates a byte slice type "[]byte"
+func ByteSliceType() *ast.ArrayType {
+	return &ast.ArrayType{Elt: ast.NewIdent("byte")}
+}
+
+// BinaryExpr creates a binary expression "x op y"
+func BinaryExpr(x ast.Expr, op token.Token, y ast.Expr) *ast.BinaryExpr {
+	return &ast.BinaryExpr{
+		X:  x,
+		Op: op,
+		Y:  y,
+	}
+}
+
+// UintLit returns an ast.BasicLit of kind INT for uint64 values
+func UintLit(value uint64) *ast.BasicLit {
+	return &ast.BasicLit{
+		Kind:  token.INT,
+		Value: fmt.Sprint(value),
+	}
+}
+
+// Field creates a field with names and type for function parameters or struct fields
+func Field(typ ast.Expr, names ...*ast.Ident) *ast.Field {
+	return &ast.Field{
+		Names: names,
+		Type:  typ,
+	}
+}
+
 func ConstToAst(val constant.Value) ast.Expr {
 	switch val.Kind() {
 	case constant.Bool:

--- a/internal/literals/fuzz_test.go
+++ b/internal/literals/fuzz_test.go
@@ -72,7 +72,9 @@ func FuzzObfuscate(f *testing.F) {
 
 		// Obfuscate the literals and print the source back.
 		rand := mathrand.New(mathrand.NewSource(randSeed))
-		srcSyntax = literals.Obfuscate(rand, srcSyntax, &info, nil)
+		srcSyntax = literals.Obfuscate(rand, srcSyntax, &info, nil, func(rand *mathrand.Rand, baseName string) string {
+			return fmt.Sprintf("%s%d", baseName, rand.Uint64())
+		})
 		count := tdirCounter.Add(1)
 		f, err := os.Create(filepath.Join(tdir, fmt.Sprintf("src_%d.go", count)))
 		qt.Assert(t, qt.IsNil(err))

--- a/internal/literals/literals.go
+++ b/internal/literals/literals.go
@@ -242,7 +242,7 @@ func obfuscateString(obfRand *obfRand, data string) *ast.CallExpr {
 
 	block.List = append(block.List, ah.ReturnStmt(ah.CallExpr(ast.NewIdent("string"), ast.NewIdent("data"))))
 
-	return ah.LambdaCallParams(params, ast.NewIdent("string"), block, args)
+	return ah.LambdaCall(params, ast.NewIdent("string"), block, args)
 }
 
 func obfuscateByteSlice(obfRand *obfRand, isPointer bool, data []byte) *ast.CallExpr {
@@ -257,13 +257,13 @@ func obfuscateByteSlice(obfRand *obfRand, isPointer bool, data []byte) *ast.Call
 			Op: token.AND,
 			X:  ast.NewIdent("data"),
 		}))
-		return ah.LambdaCallParams(params, &ast.StarExpr{
+		return ah.LambdaCall(params, &ast.StarExpr{
 			X: &ast.ArrayType{Elt: ast.NewIdent("byte")},
 		}, block, args)
 	}
 
 	block.List = append(block.List, ah.ReturnStmt(ast.NewIdent("data")))
-	return ah.LambdaCallParams(params, &ast.ArrayType{Elt: ast.NewIdent("byte")}, block, args)
+	return ah.LambdaCall(params, &ast.ArrayType{Elt: ast.NewIdent("byte")}, block, args)
 }
 
 func obfuscateByteArray(obfRand *obfRand, isPointer bool, data []byte, length int64) *ast.CallExpr {
@@ -311,10 +311,10 @@ func obfuscateByteArray(obfRand *obfRand, isPointer bool, data []byte, length in
 	block.List = append(block.List, sliceToArray...)
 
 	if isPointer {
-		return ah.LambdaCallParams(params, &ast.StarExpr{X: arrayType}, block, args)
+		return ah.LambdaCall(params, &ast.StarExpr{X: arrayType}, block, args)
 	}
 
-	return ah.LambdaCallParams(params, arrayType, block, args)
+	return ah.LambdaCall(params, arrayType, block, args)
 }
 
 func getNextObfuscator(obfRand *obfRand, size int) obfuscator {

--- a/internal/literals/obfuscators.go
+++ b/internal/literals/obfuscators.go
@@ -7,12 +7,54 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"math"
 	mathrand "math/rand"
+	ah "mvdan.cc/garble/internal/asthelper"
+	"slices"
 )
+
+// extKeyRarity probability of using an external key.
+// Larger value, greater probability of using an external key.
+// Must be between 0 and 1
+type extKeyRarity float32
+
+const (
+	rareRarity   extKeyRarity = 0.4
+	normalRarity extKeyRarity = 0.6
+	commonRarity extKeyRarity = 0.8
+)
+
+func (r extKeyRarity) Try(rand *mathrand.Rand) bool {
+	return rand.Float32() < float32(r)
+}
+
+// extKey contains all information about the external key
+type extKey struct {
+	name, typ string
+	value     uint64
+	bits      int
+	refs      int
+}
+
+func (k *extKey) Type() *ast.Ident {
+	return ast.NewIdent(k.typ)
+}
+
+func (k *extKey) Name() *ast.Ident {
+	return ast.NewIdent(k.name)
+}
+
+func (k *extKey) AddRef() {
+	k.refs++
+}
+
+func (k *extKey) IsUsed() bool {
+	return k.refs > 0
+}
 
 // obfuscator takes a byte slice and converts it to a ast.BlockStmt
 type obfuscator interface {
-	obfuscate(obfRand *mathrand.Rand, data []byte) *ast.BlockStmt
+	obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey) *ast.BlockStmt
 }
 
 var (
@@ -79,9 +121,147 @@ func operatorToReversedBinaryExpr(t token.Token, x, y ast.Expr) *ast.BinaryExpr 
 	return expr
 }
 
+const (
+	// minExtKeyCount is minimum number of external keys for one lambda call
+	minExtKeyCount = 2
+	// maxExtKeyCount is maximum number of external keys for one lambda call
+	maxExtKeyCount = 6
+
+	// minByteSliceExtKeyOps minimum number of operations with external keys for one byte slice
+	minByteSliceExtKeyOps = 2
+	// maxByteSliceExtKeyOps maximum number of operations with external keys for one byte slice
+	maxByteSliceExtKeyOps = 12
+)
+
+// extKeyRanges contains a list of different ranges of random numbers for external keys
+// Different types and bitnesses will increase the chance of changing patterns
+var extKeyRanges = []struct {
+	typ  string
+	max  uint64
+	bits int
+}{
+	{"uint8", math.MaxUint8, 8},
+	{"uint16", math.MaxUint16, 16},
+	{"uint32", math.MaxUint32, 32},
+	{"uint64", math.MaxUint64, 64},
+}
+
+func randExtKey(obfRand *mathrand.Rand, idx int) *extKey {
+	r := extKeyRanges[obfRand.Intn(len(extKeyRanges))]
+	return &extKey{
+		name:  fmt.Sprintf("__garble_ext_key_%d", idx),
+		typ:   r.typ,
+		value: obfRand.Uint64() & r.max,
+		bits:  r.bits,
+	}
+}
+
+func randExtKeys(obfRand *mathrand.Rand) []*extKey {
+	count := minExtKeyCount + obfRand.Intn(maxExtKeyCount-minExtKeyCount)
+
+	keys := make([]*extKey, count)
+	for i := 0; i < count; i++ {
+		keys[i] = randExtKey(obfRand, i)
+	}
+
+	return keys
+}
+
+func extKeysToParams(obfRand *obfRand, keys []*extKey) (params *ast.FieldList, args []ast.Expr) {
+	params = &ast.FieldList{}
+	for _, key := range keys {
+		name := key.Name()
+		if !key.IsUsed() {
+			name.Name = "_"
+		}
+		params.List = append(params.List, &ast.Field{
+			Names: []*ast.Ident{name},
+			Type:  key.Type(),
+		})
+
+		if rareRarity.Try(obfRand.Rand) {
+			args = append(args, obfRand.scrambleUsingGlobalKey(key))
+		} else {
+			args = append(args, &ast.BasicLit{
+				Kind:  token.INT,
+				Value: fmt.Sprint(key.value),
+			})
+		}
+	}
+	return
+}
+
+// dataToByteSliceWithExtKeys scramble and turns a byte slice into an AST expression like:
+//
+//	func() []byte {
+//		data := []byte("<data>")
+//		data[<index>] = data[<index>] <random operator> byte(<external key> >> <random shift>) // repeated random times
+//		return data
+//	}()
+func dataToByteSliceWithExtKeys(obfRand *mathrand.Rand, data []byte, extKeys []*extKey) ast.Expr {
+	extKeyOpCount := minByteSliceExtKeyOps + obfRand.Intn(maxByteSliceExtKeyOps-minByteSliceExtKeyOps)
+
+	var stmts []ast.Stmt
+	for i := 0; i < extKeyOpCount; i++ {
+		key := extKeys[obfRand.Intn(len(extKeys))]
+		key.AddRef()
+
+		idx, op, b := obfRand.Intn(len(data)), randOperator(obfRand), obfRand.Intn(key.bits/8)
+		data[idx] = evalOperator(op, data[idx], byte(key.value>>(b*8)))
+		stmts = append(stmts, &ast.AssignStmt{
+			Lhs: []ast.Expr{ah.IndexExpr("data", ah.IntLit(idx))},
+			Tok: token.ASSIGN,
+			Rhs: []ast.Expr{
+				operatorToReversedBinaryExpr(op,
+					ah.IndexExpr("data", ah.IntLit(idx)),
+					ah.CallExprByName("byte", &ast.BinaryExpr{
+						X:  key.Name(),
+						Op: token.SHR,
+						Y:  ah.IntLit(b * 8),
+					}),
+				),
+			},
+		})
+	}
+
+	// External keys can be applied several times to the same array element,
+	// and it is important to invert the order of execution to correctly restore the original value
+	slices.Reverse(stmts)
+
+	stmts = append([]ast.Stmt{ah.AssignDefineStmt(ast.NewIdent("data"), ah.DataToByteSlice(data))}, append(stmts, ah.ReturnStmt(ast.NewIdent("data")))...)
+	return ah.LambdaCall(&ast.ArrayType{Elt: ast.NewIdent("byte")}, ah.BlockStmt(stmts...))
+}
+
+// dataToByteSliceWithExtKeys scramble and turns a byte into an AST expression like:
+//
+//	byte(<obfuscated value>) <random operator> byte(<external key> >> <random shift>)
+func byteLitWithExtKey(obfRand *mathrand.Rand, val byte, extKeys []*extKey, rarity extKeyRarity) ast.Expr {
+	if !rarity.Try(obfRand) {
+		return ah.IntLit(int(val))
+	}
+
+	key := extKeys[obfRand.Intn(len(extKeys))]
+	key.AddRef()
+
+	op, b := randOperator(obfRand), obfRand.Intn(key.bits/8)
+	newVal := evalOperator(op, val, byte(key.value>>(b*8)))
+	return operatorToReversedBinaryExpr(op,
+		ah.CallExprByName("byte", ah.IntLit(int(newVal))),
+		ah.CallExprByName("byte", &ast.BinaryExpr{
+			X:  key.Name(),
+			Op: token.SHR,
+			Y:  ah.IntLit(b * 8),
+		}),
+	)
+}
+
 type obfRand struct {
 	*mathrand.Rand
 	testObfuscator obfuscator
+
+	globalKeysVarName string
+	globalKeys        []uint64
+	globalKeysUsed    bool
 }
 
 func (r *obfRand) nextObfuscator() obfuscator {
@@ -98,7 +278,26 @@ func (r *obfRand) nextLinearTimeObfuscator() obfuscator {
 	return Obfuscators[r.Intn(len(LinearTimeObfuscators))]
 }
 
+func (r *obfRand) scrambleUsingGlobalKey(k *extKey) ast.Expr {
+	r.globalKeysUsed = true
+
+	extKeyIdx := r.Intn(len(r.globalKeys))
+	return &ast.BinaryExpr{
+		X:  ah.CallExprByName(k.typ, ah.IndexExpr(r.globalKeysVarName, ah.IntLit(extKeyIdx))),
+		Op: token.XOR,
+		Y: &ast.BasicLit{
+			Kind: token.INT,
+			// To avoid an overflow error at compile time, truncate global key to external key bitness
+			Value: fmt.Sprint(k.value ^ (r.globalKeys[extKeyIdx] & ((1 << k.bits) - 1))),
+		},
+	}
+}
+
 func newObfRand(rand *mathrand.Rand, file *ast.File) *obfRand {
 	testObf := testPkgToObfuscatorMap[file.Name.Name]
-	return &obfRand{rand, testObf}
+	globalKeys := make([]uint64, minExtKeyCount+rand.Intn(maxExtKeyCount-minExtKeyCount))
+	for i := 0; i < len(globalKeys); i++ {
+		globalKeys[i] = rand.Uint64()
+	}
+	return &obfRand{rand, testObf, fmt.Sprintf("__garble_global_keys_%d", rand.Uint64()), globalKeys, false}
 }

--- a/internal/literals/obfuscators.go
+++ b/internal/literals/obfuscators.go
@@ -229,7 +229,7 @@ func dataToByteSliceWithExtKeys(obfRand *mathrand.Rand, data []byte, extKeys []*
 	slices.Reverse(stmts)
 
 	stmts = append([]ast.Stmt{ah.AssignDefineStmt(ast.NewIdent("data"), ah.DataToByteSlice(data))}, append(stmts, ah.ReturnStmt(ast.NewIdent("data")))...)
-	return ah.LambdaCall(&ast.ArrayType{Elt: ast.NewIdent("byte")}, ah.BlockStmt(stmts...))
+	return ah.LambdaCall(nil, &ast.ArrayType{Elt: ast.NewIdent("byte")}, ah.BlockStmt(stmts...), nil)
 }
 
 // dataToByteSliceWithExtKeys scramble and turns a byte into an AST expression like:

--- a/internal/literals/proxy.go
+++ b/internal/literals/proxy.go
@@ -1,0 +1,247 @@
+package literals
+
+import (
+	"go/ast"
+	"go/token"
+	mathrand "math/rand"
+	"strconv"
+
+	ah "mvdan.cc/garble/internal/asthelper"
+)
+
+const (
+	// minStructCount is the minimum number of proxyStructs initialized in the dispatcher.
+	minStructCount = 4
+	// maxStructCount is the maximum number of proxyStructs initialized in the dispatcher.
+	maxStructCount = 8
+	//minChildCount defines the minimum number of child elements that can be assigned to proxy structs.
+	minChildCount = 1
+	// maxChildCount defines the maximum number of child elements that can be assigned to proxy structs.
+	maxChildCount = 3
+	// minJunkValueCount defines the minimum number of junk values that can be added to a structure.
+	minJunkValueCount = 1
+	// maxJunkValueCount defines the maximum number of junk values that can be added to a structure.
+	maxJunkValueCount = 3
+	// minJunkArraySize defines the minimum size of a randomized byte array for junk data generation.
+	minJunkArraySize = 1
+	// maxJunkArraySize defines the maximum size of a randomized byte array for junk data generation.
+	maxJunkArraySize = 8
+)
+
+// proxyValue represents a named field with a type and value used in a proxy structure.
+type proxyValue struct {
+	name     string
+	typ, val ast.Expr
+}
+
+type proxyStruct struct {
+	typeName, name string
+	isPointer      bool
+
+	values []*proxyValue
+
+	children []*proxyStruct
+	parent   *proxyStruct
+}
+
+type proxyDispatcher struct {
+	rand     *mathrand.Rand
+	nameFunc NameProviderFunc
+
+	root           *proxyStruct
+	flattenStructs []*proxyStruct
+}
+
+func (d *proxyDispatcher) initialize() {
+	flattenStructs := make([]*proxyStruct, d.rand.Intn(maxStructCount-minStructCount)+minStructCount)
+	for i := 0; i < len(flattenStructs); i++ {
+		flattenStructs[i] = &proxyStruct{
+			typeName:  d.nameFunc(d.rand, "proxyStructName"+strconv.Itoa(i)),
+			name:      d.nameFunc(d.rand, "proxyStructFieldName"+strconv.Itoa(i)),
+			isPointer: d.rand.Intn(2) == 0,
+		}
+	}
+
+	root := &proxyStruct{
+		name:     d.nameFunc(d.rand, "rootStructName"),
+		typeName: d.nameFunc(d.rand, "rootStructType"),
+		parent:   nil,
+	}
+	d.root = root
+
+	unassigned := append([]*proxyStruct(nil), flattenStructs...)
+	queue := []*proxyStruct{root}
+	for len(unassigned) > 0 && len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		childCount := d.rand.Intn(maxChildCount-minChildCount) + minChildCount
+		if childCount > len(unassigned) {
+			childCount = len(unassigned)
+		}
+
+		for i := 0; i < childCount; i++ {
+			child := unassigned[0]
+			unassigned = unassigned[1:]
+
+			child.parent = current
+			current.children = append(current.children, child)
+			queue = append(queue, child)
+		}
+	}
+
+	d.flattenStructs = append(flattenStructs, root)
+}
+
+// buildPath creates an AST expression that represents a field access path
+// from the root of a nested struct hierarchy to a specific field.
+// Example: root.child.grandchild.fieldName
+func buildPath(strct *proxyStruct, valueName string) ast.Expr {
+	var stack []*proxyStruct
+	for s := strct; s != nil; s = s.parent {
+		stack = append(stack, s)
+	}
+
+	var expr ast.Expr = ast.NewIdent(stack[len(stack)-1].name)
+	for i := len(stack) - 2; i >= 0; i-- {
+		expr = &ast.SelectorExpr{
+			X:   expr,
+			Sel: ast.NewIdent(stack[i].name),
+		}
+	}
+
+	return &ast.SelectorExpr{
+		X:   expr,
+		Sel: ast.NewIdent(valueName),
+	}
+}
+
+func (d *proxyDispatcher) HideValue(val, typ ast.Expr) ast.Expr {
+	if d.root == nil {
+		d.initialize()
+	}
+
+	strct := d.flattenStructs[d.rand.Intn(len(d.flattenStructs))]
+	valueName := d.nameFunc(d.rand, strct.name+"_"+strct.typeName+"_"+strconv.Itoa(len(strct.values)))
+	strct.values = append(strct.values, &proxyValue{
+		name: valueName,
+		typ:  typ,
+		val:  val,
+	})
+	return buildPath(strct, valueName)
+}
+
+func (d *proxyDispatcher) generateStructLiteral(s *proxyStruct) ast.Expr {
+	var fields []ast.Expr
+	for _, child := range s.children {
+		expr := d.generateStructLiteral(child)
+		if child.isPointer {
+			expr = &ast.UnaryExpr{
+				Op: token.AND,
+				X:  expr,
+			}
+		}
+		fields = append(fields, &ast.KeyValueExpr{
+			Key:   ast.NewIdent(child.name),
+			Value: expr,
+		})
+	}
+
+	for _, val := range s.values {
+		fields = append(fields, &ast.KeyValueExpr{
+			Key:   ast.NewIdent(val.name),
+			Value: val.val,
+		})
+	}
+
+	d.rand.Shuffle(len(fields), func(i, j int) {
+		fields[i], fields[j] = fields[j], fields[i]
+	})
+
+	return &ast.CompositeLit{
+		Type: ast.NewIdent(s.typeName),
+		Elts: fields,
+	}
+}
+
+// junkValue generates and returns a proxyValue containing a randomized byte array of variable size
+func (d *proxyDispatcher) junkValue() *proxyValue {
+	size := d.rand.Intn(maxJunkArraySize-minJunkArraySize+1) + minJunkArraySize
+	data := make([]byte, size)
+	d.rand.Read(data)
+
+	dummyDataExpr := &ast.CompositeLit{
+		Type: &ast.ArrayType{
+			Len: ah.IntLit(size),
+			Elt: ast.NewIdent("byte"),
+		},
+		Elts: ah.DataToArray(data).Elts,
+	}
+	return &proxyValue{
+		name: d.nameFunc(d.rand, "junkValue"),
+		typ: &ast.ArrayType{
+			Len: ah.IntLit(size),
+			Elt: ast.NewIdent("byte"),
+		},
+		val: dummyDataExpr,
+	}
+}
+
+func (d *proxyDispatcher) AddToFile(file *ast.File) {
+	if d.root == nil {
+		return
+	}
+
+	for _, strct := range d.flattenStructs {
+		dummyCount := d.rand.Intn(maxJunkValueCount-minJunkValueCount+1) + minJunkValueCount
+		for i := 0; i < dummyCount; i++ {
+			strct.values = append(strct.values, d.junkValue())
+		}
+
+		structType := &ast.StructType{Fields: &ast.FieldList{}}
+		for _, child := range strct.children {
+			var typ ast.Expr = ast.NewIdent(child.typeName)
+			if child.isPointer {
+				typ = &ast.StarExpr{X: typ}
+			}
+			structType.Fields.List = append(structType.Fields.List, &ast.Field{
+				Names: []*ast.Ident{ast.NewIdent(child.name)},
+				Type:  typ,
+			})
+		}
+
+		for _, value := range strct.values {
+			structType.Fields.List = append(structType.Fields.List, &ast.Field{
+				Names: []*ast.Ident{ast.NewIdent(value.name)},
+				Type:  value.typ,
+			})
+		}
+
+		d.rand.Shuffle(len(structType.Fields.List), func(i, j int) {
+			structType.Fields.List[i], structType.Fields.List[j] = structType.Fields.List[j], structType.Fields.List[i]
+		})
+
+		file.Decls = append(file.Decls, &ast.GenDecl{
+			Tok: token.TYPE,
+			Specs: []ast.Spec{&ast.TypeSpec{
+				Name: ast.NewIdent(strct.typeName),
+				Type: structType,
+			}},
+		})
+	}
+
+	file.Decls = append(file.Decls, &ast.GenDecl{
+		Tok: token.VAR,
+		Specs: []ast.Spec{&ast.ValueSpec{
+			Names:  []*ast.Ident{ast.NewIdent(d.root.name)},
+			Values: []ast.Expr{d.generateStructLiteral(d.root)},
+		}},
+	})
+}
+
+func newProxyDispatcher(rand *mathrand.Rand, nameFunc NameProviderFunc) *proxyDispatcher {
+	return &proxyDispatcher{
+		rand:     rand,
+		nameFunc: nameFunc,
+	}
+}

--- a/internal/literals/seed.go
+++ b/internal/literals/seed.go
@@ -16,30 +16,29 @@ type seed struct{}
 // check that the obfuscator interface is implemented
 var _ obfuscator = seed{}
 
-func (seed) obfuscate(obfRand *mathrand.Rand, data []byte) *ast.BlockStmt {
+func (seed) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey) *ast.BlockStmt {
 	seed := byte(obfRand.Uint32())
 	originalSeed := seed
 
 	op := randOperator(obfRand)
-
 	var callExpr *ast.CallExpr
 	for i, b := range data {
 		encB := evalOperator(op, b, seed)
 		seed += encB
 
 		if i == 0 {
-			callExpr = ah.CallExpr(ast.NewIdent("fnc"), ah.IntLit(int(encB)))
+			callExpr = ah.CallExpr(ast.NewIdent("fnc"), byteLitWithExtKey(obfRand, encB, extKeys, commonRarity))
 			continue
 		}
 
-		callExpr = ah.CallExpr(callExpr, ah.IntLit(int(encB)))
+		callExpr = ah.CallExpr(callExpr, byteLitWithExtKey(obfRand, encB, extKeys, rareRarity))
 	}
 
 	return ah.BlockStmt(
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("seed")},
 			Tok: token.DEFINE,
-			Rhs: []ast.Expr{ah.CallExpr(ast.NewIdent("byte"), ah.IntLit(int(originalSeed)))},
+			Rhs: []ast.Expr{ah.CallExprByName("byte", byteLitWithExtKey(obfRand, originalSeed, extKeys, commonRarity))},
 		},
 		&ast.DeclStmt{
 			Decl: &ast.GenDecl{

--- a/internal/literals/seed.go
+++ b/internal/literals/seed.go
@@ -16,7 +16,7 @@ type seed struct{}
 // check that the obfuscator interface is implemented
 var _ obfuscator = seed{}
 
-func (seed) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey) *ast.BlockStmt {
+func (seed) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*externalKey) *ast.BlockStmt {
 	seed := byte(obfRand.Uint32())
 	originalSeed := seed
 
@@ -27,18 +27,18 @@ func (seed) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey) *a
 		seed += encB
 
 		if i == 0 {
-			callExpr = ah.CallExpr(ast.NewIdent("fnc"), byteLitWithExtKey(obfRand, encB, extKeys, commonRarity))
+			callExpr = ah.CallExpr(ast.NewIdent("fnc"), byteLitWithExtKey(obfRand, encB, extKeys, highProb))
 			continue
 		}
 
-		callExpr = ah.CallExpr(callExpr, byteLitWithExtKey(obfRand, encB, extKeys, rareRarity))
+		callExpr = ah.CallExpr(callExpr, byteLitWithExtKey(obfRand, encB, extKeys, lowProb))
 	}
 
 	return ah.BlockStmt(
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("seed")},
 			Tok: token.DEFINE,
-			Rhs: []ast.Expr{ah.CallExprByName("byte", byteLitWithExtKey(obfRand, originalSeed, extKeys, commonRarity))},
+			Rhs: []ast.Expr{ah.CallExprByName("byte", byteLitWithExtKey(obfRand, originalSeed, extKeys, highProb))},
 		},
 		&ast.DeclStmt{
 			Decl: &ast.GenDecl{

--- a/internal/literals/shuffle.go
+++ b/internal/literals/shuffle.go
@@ -16,7 +16,7 @@ type shuffle struct{}
 // check that the obfuscator interface is implemented
 var _ obfuscator = shuffle{}
 
-func (shuffle) obfuscate(obfRand *mathrand.Rand, data []byte) *ast.BlockStmt {
+func (shuffle) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey) *ast.BlockStmt {
 	key := make([]byte, len(data))
 	obfRand.Read(key)
 
@@ -69,12 +69,12 @@ func (shuffle) obfuscate(obfRand *mathrand.Rand, data []byte) *ast.BlockStmt {
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("fullData")},
 			Tok: token.DEFINE,
-			Rhs: []ast.Expr{ah.DataToByteSlice(shuffledFullData)},
+			Rhs: []ast.Expr{dataToByteSliceWithExtKeys(obfRand, shuffledFullData, extKeys)},
 		},
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("idxKey")},
 			Tok: token.DEFINE,
-			Rhs: []ast.Expr{ah.DataToByteSlice(idxKey)},
+			Rhs: []ast.Expr{dataToByteSliceWithExtKeys(obfRand, idxKey, extKeys)},
 		},
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("data")},

--- a/internal/literals/shuffle.go
+++ b/internal/literals/shuffle.go
@@ -16,9 +16,9 @@ type shuffle struct{}
 // check that the obfuscator interface is implemented
 var _ obfuscator = shuffle{}
 
-func (shuffle) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey) *ast.BlockStmt {
+func (shuffle) obfuscate(rand *mathrand.Rand, data []byte, extKeys []*externalKey) *ast.BlockStmt {
 	key := make([]byte, len(data))
-	obfRand.Read(key)
+	rand.Read(key)
 
 	const (
 		minIdxKeySize = 2
@@ -26,7 +26,7 @@ func (shuffle) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey)
 	)
 
 	idxKeySize := minIdxKeySize
-	if tmp := obfRand.Intn(len(data)); tmp > idxKeySize {
+	if tmp := rand.Intn(len(data)); tmp > idxKeySize {
 		idxKeySize = tmp
 	}
 	if idxKeySize > maxIdxKeySize {
@@ -34,19 +34,19 @@ func (shuffle) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey)
 	}
 
 	idxKey := make([]byte, idxKeySize)
-	obfRand.Read(idxKey)
+	rand.Read(idxKey)
 
 	fullData := make([]byte, len(data)+len(key))
 	operators := make([]token.Token, len(fullData))
 	for i := range operators {
-		operators[i] = randOperator(obfRand)
+		operators[i] = randOperator(rand)
 	}
 
 	for i, b := range key {
 		fullData[i], fullData[i+len(data)] = evalOperator(operators[i], data[i], b), b
 	}
 
-	shuffledIdxs := obfRand.Perm(len(fullData))
+	shuffledIdxs := rand.Perm(len(fullData))
 
 	shuffledFullData := make([]byte, len(fullData))
 	for i, b := range fullData {
@@ -55,7 +55,7 @@ func (shuffle) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey)
 
 	args := []ast.Expr{ast.NewIdent("data")}
 	for i := range data {
-		keyIdx := obfRand.Intn(idxKeySize)
+		keyIdx := rand.Intn(idxKeySize)
 		k := int(idxKey[keyIdx])
 
 		args = append(args, operatorToReversedBinaryExpr(
@@ -69,12 +69,12 @@ func (shuffle) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey)
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("fullData")},
 			Tok: token.DEFINE,
-			Rhs: []ast.Expr{dataToByteSliceWithExtKeys(obfRand, shuffledFullData, extKeys)},
+			Rhs: []ast.Expr{dataToByteSliceWithExtKeys(rand, shuffledFullData, extKeys)},
 		},
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("idxKey")},
 			Tok: token.DEFINE,
-			Rhs: []ast.Expr{dataToByteSliceWithExtKeys(obfRand, idxKey, extKeys)},
+			Rhs: []ast.Expr{dataToByteSliceWithExtKeys(rand, idxKey, extKeys)},
 		},
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("data")},

--- a/internal/literals/simple.go
+++ b/internal/literals/simple.go
@@ -7,6 +7,7 @@ import (
 	"go/ast"
 	"go/token"
 	mathrand "math/rand"
+
 	ah "mvdan.cc/garble/internal/asthelper"
 )
 
@@ -15,11 +16,11 @@ type simple struct{}
 // check that the obfuscator interface is implemented
 var _ obfuscator = simple{}
 
-func (simple) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey) *ast.BlockStmt {
+func (simple) obfuscate(rand *mathrand.Rand, data []byte, extKeys []*externalKey) *ast.BlockStmt {
 	key := make([]byte, len(data))
-	obfRand.Read(key)
+	rand.Read(key)
 
-	op := randOperator(obfRand)
+	op := randOperator(rand)
 	for i, b := range key {
 		data[i] = evalOperator(op, data[i], b)
 	}
@@ -28,12 +29,12 @@ func (simple) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey) 
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("key")},
 			Tok: token.DEFINE,
-			Rhs: []ast.Expr{dataToByteSliceWithExtKeys(obfRand, key, extKeys)},
+			Rhs: []ast.Expr{dataToByteSliceWithExtKeys(rand, key, extKeys)},
 		},
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("data")},
 			Tok: token.DEFINE,
-			Rhs: []ast.Expr{dataToByteSliceWithExtKeys(obfRand, data, extKeys)},
+			Rhs: []ast.Expr{dataToByteSliceWithExtKeys(rand, data, extKeys)},
 		},
 		&ast.RangeStmt{
 			Key:   ast.NewIdent("i"),

--- a/internal/literals/simple.go
+++ b/internal/literals/simple.go
@@ -7,7 +7,6 @@ import (
 	"go/ast"
 	"go/token"
 	mathrand "math/rand"
-
 	ah "mvdan.cc/garble/internal/asthelper"
 )
 
@@ -16,7 +15,7 @@ type simple struct{}
 // check that the obfuscator interface is implemented
 var _ obfuscator = simple{}
 
-func (simple) obfuscate(obfRand *mathrand.Rand, data []byte) *ast.BlockStmt {
+func (simple) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey) *ast.BlockStmt {
 	key := make([]byte, len(data))
 	obfRand.Read(key)
 
@@ -29,12 +28,12 @@ func (simple) obfuscate(obfRand *mathrand.Rand, data []byte) *ast.BlockStmt {
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("key")},
 			Tok: token.DEFINE,
-			Rhs: []ast.Expr{ah.DataToByteSlice(key)},
+			Rhs: []ast.Expr{dataToByteSliceWithExtKeys(obfRand, key, extKeys)},
 		},
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("data")},
 			Tok: token.DEFINE,
-			Rhs: []ast.Expr{ah.DataToByteSlice(data)},
+			Rhs: []ast.Expr{dataToByteSliceWithExtKeys(obfRand, data, extKeys)},
 		},
 		&ast.RangeStmt{
 			Key:   ast.NewIdent("i"),

--- a/internal/literals/split.go
+++ b/internal/literals/split.go
@@ -66,7 +66,7 @@ func encryptChunks(chunks [][]byte, op token.Token, key byte) {
 	}
 }
 
-func (split) obfuscate(obfRand *mathrand.Rand, data []byte) *ast.BlockStmt {
+func (split) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey) *ast.BlockStmt {
 	var chunks [][]byte
 	// Short arrays should be divided into single-byte fragments
 	if len(data)/maxChunkSize < minCaseCount {
@@ -131,10 +131,10 @@ func (split) obfuscate(obfRand *mathrand.Rand, data []byte) *ast.BlockStmt {
 		}
 
 		if len(chunk) != 1 {
-			appendCallExpr.Args = append(appendCallExpr.Args, ah.StringLit(string(chunk)))
+			appendCallExpr.Args = append(appendCallExpr.Args, dataToByteSliceWithExtKeys(obfRand, chunk, extKeys))
 			appendCallExpr.Ellipsis = 1
 		} else {
-			appendCallExpr.Args = append(appendCallExpr.Args, ah.IntLit(int(chunk[0])))
+			appendCallExpr.Args = append(appendCallExpr.Args, byteLitWithExtKey(obfRand, chunk[0], extKeys, rareRarity))
 		}
 
 		switchCases = append(switchCases, &ast.CaseClause{
@@ -168,7 +168,7 @@ func (split) obfuscate(obfRand *mathrand.Rand, data []byte) *ast.BlockStmt {
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("decryptKey")},
 			Tok: token.DEFINE,
-			Rhs: []ast.Expr{ah.IntLit(int(decryptKeyInitial))},
+			Rhs: []ast.Expr{ah.CallExprByName("int", byteLitWithExtKey(obfRand, decryptKeyInitial, extKeys, normalRarity))},
 		},
 		&ast.ForStmt{
 			Init: &ast.AssignStmt{

--- a/internal/literals/swap.go
+++ b/internal/literals/swap.go
@@ -58,7 +58,7 @@ func generateSwapCount(obfRand *mathrand.Rand, dataLen int) int {
 	return swapCount
 }
 
-func (swap) obfuscate(obfRand *mathrand.Rand, data []byte) *ast.BlockStmt {
+func (swap) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey) *ast.BlockStmt {
 	swapCount := generateSwapCount(obfRand, len(data))
 	shiftKey := byte(obfRand.Uint32())
 
@@ -76,7 +76,7 @@ func (swap) obfuscate(obfRand *mathrand.Rand, data []byte) *ast.BlockStmt {
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("data")},
 			Tok: token.DEFINE,
-			Rhs: []ast.Expr{ah.DataToByteSlice(data)},
+			Rhs: []ast.Expr{dataToByteSliceWithExtKeys(obfRand, data, extKeys)},
 		},
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("positions")},
@@ -118,7 +118,7 @@ func (swap) obfuscate(obfRand *mathrand.Rand, data []byte) *ast.BlockStmt {
 							}),
 						},
 						Op: token.ADD,
-						Y:  ah.IntLit(int(shiftKey)),
+						Y:  byteLitWithExtKey(obfRand, shiftKey, extKeys, commonRarity),
 					}},
 				},
 				&ast.AssignStmt{

--- a/internal/literals/swap.go
+++ b/internal/literals/swap.go
@@ -58,13 +58,13 @@ func generateSwapCount(obfRand *mathrand.Rand, dataLen int) int {
 	return swapCount
 }
 
-func (swap) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey) *ast.BlockStmt {
-	swapCount := generateSwapCount(obfRand, len(data))
-	shiftKey := byte(obfRand.Uint32())
+func (swap) obfuscate(rand *mathrand.Rand, data []byte, extKeys []*externalKey) *ast.BlockStmt {
+	swapCount := generateSwapCount(rand, len(data))
+	shiftKey := byte(rand.Uint32())
 
-	op := randOperator(obfRand)
+	op := randOperator(rand)
 
-	positions := genRandIntSlice(obfRand, len(data), swapCount)
+	positions := genRandIntSlice(rand, len(data), swapCount)
 	for i := len(positions) - 2; i >= 0; i -= 2 {
 		// Generate local key for xor based on random key and byte position
 		localKey := byte(i) + byte(positions[i]^positions[i+1]) + shiftKey
@@ -76,7 +76,7 @@ func (swap) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey) *a
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("data")},
 			Tok: token.DEFINE,
-			Rhs: []ast.Expr{dataToByteSliceWithExtKeys(obfRand, data, extKeys)},
+			Rhs: []ast.Expr{dataToByteSliceWithExtKeys(rand, data, extKeys)},
 		},
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("positions")},
@@ -118,7 +118,7 @@ func (swap) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*extKey) *a
 							}),
 						},
 						Op: token.ADD,
-						Y:  byteLitWithExtKey(obfRand, shiftKey, extKeys, commonRarity),
+						Y:  byteLitWithExtKey(rand, shiftKey, extKeys, highProb),
 					}},
 				},
 				&ast.AssignStmt{

--- a/main.go
+++ b/main.go
@@ -1823,7 +1823,7 @@ func (tf *transformer) transformGoFile(file *ast.File) *ast.File {
 	// because obfuscated literals sometimes escape to heap,
 	// and that's not allowed in the runtime itself.
 	if flagLiterals && tf.curPkg.ToObfuscate {
-		file = literals.Obfuscate(tf.obfRand, file, tf.info, tf.linkerVariableStrings)
+		file = literals.Obfuscate(tf.obfRand, file, tf.info, tf.linkerVariableStrings, randomName)
 
 		// some imported constants might not be needed anymore, remove unnecessary imports
 		tf.useAllImports(file)

--- a/testdata/script/literals.txtar
+++ b/testdata/script/literals.txtar
@@ -54,10 +54,7 @@ grep '^(\s+)?\w+ = .*\bappend\(\w+,(\s+\w+\[\d+\^\s.+\][\^\-+]\w+\[\d+\^\s.+\],?
 grep '^\s+type \w+ func\(byte\) \w+$' debug1/test/main/extra_literals.go
 
 # Check external keys
-grep '__garble_ext_key_' debug1/test/main/extra_literals.go
-
-# Check global keys
-grep '__garble_global_keys_' debug1/test/main/extra_literals.go
+grep 'garbleEx1ternalKey' debug1/test/main/extra_literals.go
 
 # Finally, sanity check that we can build all of std with -literals.
 # Analogous to gogarble.txt.

--- a/testdata/script/literals.txtar
+++ b/testdata/script/literals.txtar
@@ -54,7 +54,7 @@ grep '^(\s+)?\w+ = .*\bappend\(\w+,(\s+\w+\[\d+\^\s.+\][\^\-+]\w+\[\d+\^\s.+\],?
 grep '^\s+type \w+ func\(byte\) \w+$' debug1/test/main/extra_literals.go
 
 # Check external keys
-grep 'garbleEx1ternalKey' debug1/test/main/extra_literals.go
+grep 'garbleExternalKey' debug1/test/main/extra_literals.go
 
 # Finally, sanity check that we can build all of std with -literals.
 # Analogous to gogarble.txt.

--- a/testdata/script/literals.txtar
+++ b/testdata/script/literals.txtar
@@ -53,6 +53,12 @@ grep '^(\s+)?\w+ = .*\bappend\(\w+,(\s+\w+\[\d+\^\s.+\][\^\-+]\w+\[\d+\^\s.+\],?
 # XorSeed obfuscator. Detect type decFunc func(byte) decFunc
 grep '^\s+type \w+ func\(byte\) \w+$' debug1/test/main/extra_literals.go
 
+# Check external keys
+grep '__garble_ext_key_' debug1/test/main/extra_literals.go
+
+# Check global keys
+grep '__garble_global_keys_' debug1/test/main/extra_literals.go
+
 # Finally, sanity check that we can build all of std with -literals.
 # Analogous to gogarble.txt.
 exec garble -literals build std


### PR DESCRIPTION
__WIP__


Now implemented “external keys”, with random bit count (8/16/32/64). One key can be used many times and using bit shifting each key can be used differently


Roadmap:
1. Add global keys, which would make deobfuscation even more complicated. Any ideas are welcome @lu4p 
2. Eliminate hardcoded constants (or add docs :) )
3. Add `string([]byte(""))` pattern hiding (via proxy)
4. Add documentation 






<details>
<summary>Code examples</summary>

```go
// no obfuscation
func main() {
	fmt.Println("Hello world")
}

// simple
func main() {
	fmt.Println(func(__ek_11725047838393011298 uint16, _ uint16, _ uint64, __ek_15442629010710282703 uint8, _ uint16, __ek_15133517871929446378 uint32, _ uint8, __ek_12796333468252078615 uint64) string {
		key := func() []byte {
			data := []byte("Plҥ\xa3[\x12v\x11\x97K")
			data[7] = data[7] - byte(__ek_15133517871929446378>>24)
			data[10] = data[10] ^ byte(__ek_11725047838393011298>>8)
			data[2] = data[2] ^ byte(__ek_12796333468252078615>>48)
			data[6] = data[6] - byte(__ek_15442629010710282703>>0)
			data[1] = data[1] - byte(__ek_15133517871929446378>>24)
			return data
		}()
		data := []byte("\x18*\x0e\xc9\xcc{06c\xfb%")
		for i, b := range key {
			data[i] = data[i] ^ b
		}
		return string(data)
	}(2568, 2634, 3921319057942851920, 203, 59873, 496871930, 243, 13452259376514879379))
}

// swap
func main() {
	fmt.Println(func(_ uint16, __ek_16698843071197877907 uint16, _ uint8, __ek_14615007820358085783 uint8, __ek_2660186290119384114 uint64, _ uint32, _ uint32, __ek_6765966717164870364 uint64) string {
		data := func() []byte {
			data := []byte("rr\xc0\xd4\xc6tNor\xa8\x10")
			data[0] = data[0] ^ byte(__ek_6765966717164870364>>0)
			data[10] = data[10] - byte(__ek_2660186290119384114>>16)
			data[6] = data[6] + byte(__ek_16698843071197877907>>8)
			data[1] = data[1] - byte(__ek_2660186290119384114>>24)
			data[5] = data[5] - byte(__ek_14615007820358085783>>0)
			return data
		}()
		positions := [...]byte{10, 10, 0, 9, 10, 3, 5, 10, 10, 3, 4, 3, 9, 2}
		for i := 0; i < 14; i += 2 {
			localKey := byte(i) + byte(positions[i]^positions[i+1]) + (byte(28) ^ byte(__ek_2660186290119384114>>16))
			data[positions[i]], data[positions[i+1]] = data[positions[i+1]]+localKey, data[positions[i]]+localKey
		}
		return string(data)
	}(10893, 10545, 179, 251, 10106724231502467345, 2153608741, 2424127044, 16266419076034768210))
}

// split
func main() {
	fmt.Println(func(_ uint64, _ uint32, __ek_10553311422834509489 uint32, _ uint32, __ek_10597153128353794973 uint8, _ uint32, _ uint8) string {
		data := make([]byte, 0, 12)
		i := 1
		decryptKey := int(byte(145) ^ byte(__ek_10553311422834509489>>16))
		for counter := 0; i != 3; counter++ {
			decryptKey ^= i * counter
			switch i {
			case 9:
				for y := range data {
					data[y] = data[y] ^ byte(decryptKey^y)
				}
				i = 3
			case 2:
				i = 5
				data = append(data, 19)
			case 6:
				i = 7
				data = append(data, 9)
			case 7:
				data = append(data, byte(52)+byte(__ek_10597153128353794973>>0))
				i = 11
			case 0:
				i = 12
				data = append(data, 28)
			case 4:
				data = append(data, 23)
				i = 2
			case 5:
				i = 6
				data = append(data, 93)
			case 10:
				data = append(data, byte(202)^byte(__ek_10597153128353794973>>0))
				i = 9
			case 8:
				i = 10
				data = append(data, 29)
			case 11:
				data = append(data, 2)
				i = 8
			case 12:
				i = 4
				data = append(data, 22)
			case 1:
				data = append(data, 48)
				i = 0
			}
		}
		return string(data)
	}(9767650945150019100, 3538353787, 720247858, 670129593, 220, 2230471821, 151))
}

// shuffle
func main() {
	fmt.Println(func(__ek_10329494355374689123 uint32, __ek_14941566625470174949 uint32, __ek_12646083717148524100 uint32, __ek_133237833610477955 uint32, _ uint8, __ek_16820180909362607653 uint8, __ek_16851294987403251015 uint16, _ uint8) string {
		fullData := func() []byte {
			data := []byte("TܠB$\xeb\xd9\xc1!0s\x9c\xccݤ\xbd\x80\x94\x99\xbe-\xa0")
			data[8] = data[8] + byte(__ek_133237833610477955>>16)
			data[7] = data[7] + byte(__ek_10329494355374689123>>24)
			data[10] = data[10] ^ byte(__ek_16851294987403251015>>8)
			data[7] = data[7] + byte(__ek_14941566625470174949>>24)
			data[6] = data[6] ^ byte(__ek_12646083717148524100>>24)
			data[18] = data[18] ^ byte(__ek_16820180909362607653>>0)
			data[16] = data[16] + byte(__ek_16820180909362607653>>0)
			data[21] = data[21] - byte(__ek_16820180909362607653>>0)
			data[16] = data[16] + byte(__ek_16820180909362607653>>0)
			data[17] = data[17] - byte(__ek_10329494355374689123>>0)
			data[1] = data[1] - byte(__ek_12646083717148524100>>24)
			return data
		}()
		idxKey := func() []byte {
			data := []byte("\xf0\x87j\xf1D\xf0\x97:")
			data[3] = data[3] + byte(__ek_133237833610477955>>16)
			data[2] = data[2] - byte(__ek_10329494355374689123>>16)
			data[2] = data[2] - byte(__ek_14941566625470174949>>16)
			data[0] = data[0] - byte(__ek_16820180909362607653>>0)
			return data
		}()
		data := make([]byte, 0, 12)
		data = append(data, fullData[246^int(idxKey[5])]^fullData[254^int(idxKey[5])], fullData[89^int(idxKey[0])]+fullData[75^int(idxKey[0])], fullData[71^int(idxKey[0])]^fullData[66^int(idxKey[0])], fullData[131^int(idxKey[1])]+fullData[141^int(idxKey[1])], fullData[77^int(idxKey[2])]+fullData[90^int(idxKey[2])], fullData[129^int(idxKey[3])]+fullData[141^int(idxKey[3])], fullData[75^int(idxKey[2])]^fullData[69^int(idxKey[2])], fullData[226^int(idxKey[5])]+fullData[249^int(idxKey[5])], fullData[69^int(idxKey[0])]-fullData[91^int(idxKey[0])], fullData[70^int(idxKey[4])]+fullData[84^int(idxKey[4])], fullData[130^int(idxKey[6])]^fullData[144^int(idxKey[6])])
		return string(data)
	}(618585161, 3107849982, 896102478, 3163618181, 184, 166, 15221, 232))
}

// seed
func main() {
	fmt.Println(func(__ek_7881529660392696364 uint8, _ uint64, _ uint32, _ uint16, _ uint16, __ek_4913274346185192430 uint32, _ uint32) string {
		seed := byte(90)
		var data []byte
		type decFunc func(byte) decFunc
		var fnc decFunc
		fnc = func(x byte) decFunc { data = append(data, x+seed); seed += x; return fnc }
		fnc(byte(205) - byte(__ek_4913274346185192430>>0))(byte(133) + byte(__ek_4913274346185192430>>8))(7)(0)(3)(177)(byte(0) + byte(__ek_7881529660392696364>>0))(248)(3)(250)(byte(79) - byte(__ek_7881529660392696364>>0))
		return string(data)
	}(87, 8047631583729643452, 1083076900, 4058, 54871, 1385863391, 1401467317))
}
```

</details>

Closes https://github.com/burrowers/garble/issues/926