### PR TITLE
Add Sentry-compatible output flag and handling for reverse command

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ var (
 	flagDebug    bool
 	flagDebugDir string
 	flagSeed     seedFlag
+	flagSentry   bool
 	// TODO(pagran): in the future, when control flow obfuscation will be stable migrate to flag
 	flagControlFlow = os.Getenv("GARBLE_EXPERIMENTAL_CONTROLFLOW") == "1"
 )
@@ -69,9 +70,10 @@ func init() {
 	flagSet.BoolVar(&flagDebug, "debug", false, "Print debug logs to stderr")
 	flagSet.StringVar(&flagDebugDir, "debugdir", "", "Write the obfuscated source to a directory, e.g. -debugdir=out")
 	flagSet.Var(&flagSeed, "seed", "Provide a base64-encoded seed, e.g. -seed=o9WDTZ4CN4w\nFor a random seed, provide -seed=random")
+	flagSet.BoolVar(&flagSentry, "sentry", false, "Enable Sentry-compatible output")
 }
 
-var rxGarbleFlag = regexp.MustCompile(`-(?:literals|tiny|debug|debugdir|seed)(?:$|=)`)
+var rxGarbleFlag = regexp.MustCompile(`-(?:literals|tiny|debug|debugdir|seed|sentry)(?:$|=)`)
 
 type seedFlag struct {
 	random bool
@@ -132,6 +134,7 @@ The following commands are supported:
 	run            replace "go run"
 	reverse        de-obfuscate output such as stack traces
 	version        print the version and build settings of the garble binary
+	sentry         enable Sentry-compatible output for reverse
 
 To learn more about a command, run "garble help <command>".
 

--- a/reverse.go
+++ b/reverse.go
@@ -108,6 +108,21 @@ One can reverse a captured panic stack trace as follows:
 					origPos := fmt.Sprintf("%s:%d", goFile, pos.Offset)
 					newFilename := hashWithPackage(lpkg, origPos) + ".go"
 
+					if flagSentry {
+						// Sentry/Bugsink Python-like stack trace mapping.
+						replaces = append(replaces,
+							fmt.Sprintf("%s, line 1", newFilename),
+							fmt.Sprintf("%s/%s, line %d", lpkg.ImportPath, goFile, pos.Line),
+						)
+
+						// Sentry/Bugsink json stack trace mapping.
+						replaces = append(replaces,
+							fmt.Sprintf(`"filename": "%s", "lineno": 1`, newFilename),
+							fmt.Sprintf(`"filename": "%s/%s", "lineno": %d`, lpkg.ImportPath, goFile, pos.Line),
+						)
+						continue
+					}
+
 					// Do "obfuscated.go:1", corresponding to the call site's line.
 					// Most common in stack traces.
 					replaces = append(replaces,


### PR DESCRIPTION
Adding support for deobfuscate Sentry/Bugsink stack trace.

Example:
For Plaintext
```
Traceback (most recent call last):
  File ajB5WpM.go, line 1, in main
    
  File YVDM2UvBa1pK.go, line 1, in (*GcPJXBo0O).Msg
    
  File PmRYfUF7fV.go, line 1, in (*GcPJXBo0O).ia6J1v
    
  File QR8skLy.go, line 1, in (*GcPJXBo0O).jqLodorEA6
    
  File u9qkupM.go, line 1, in g6qBd3.WriteLevel
    
  File vAaFg7om.go, line 1, in (*TkPbGafI).WriteLevel
    
  File nQS6ZC5.go, line 1, in zZKJ7aezE
    
  File HY7R3HYUYbp0.go, line 1, in Sh0RufN
    
  File A8_tfqaEPrO.go, line 1, in zZKJ7aezE.func1
    
  File sAof1b2PSs.go, line 1, in NTSkDRlZS
```
in this
```
Traceback (most recent call last):
  File app/cmd/app/main.go, line 56, in main
    
  File github.com/rs/zerolog/event.go, line 110, in (*Event).Msg
    
  File github.com/rs/zerolog/event.go, line 151, in (*Event).msg
    
  File github.com/rs/zerolog/event.go, line 80, in (*Event).write
    
  File github.com/rs/zerolog/writer.go, line 98, in multiLevelWriter.WriteLevel
    
  File github.com/getsentry/sentry-go/zerolog/sentryzerolog.go, line 213, in (*Writer).WriteLevel
    
  File github.com/getsentry/sentry-go/zerolog/sentryzerolog.go, line 263, in parseLogEvent
    
  File github.com/buger/jsonparser/parser.go, line 1128, in ObjectEach
    
  File github.com/getsentry/sentry-go/zerolog/sentryzerolog.go, line 271, in parseLogEvent.func1
    
  File github.com/getsentry/sentry-go/stacktrace.go, line 29, in NewStacktrace
```

and for json:
```json
{
  "exception": [
    {
      "value": "can't continue",
      "stacktrace": {
        "frames": [
          {
            "function": "main",
            "module": "main",
            "filename": "ajB5WpM.go",
            "lineno": 1,
            "in_app": true
          },
          {
            "function": "(*GcPJXBo0O).Msg",
            "module": "pNelqfz",
            "filename": "YVDM2UvBa1pK.go",
            "lineno": 1,
            "in_app": true
          },
          {
            "function": "(*GcPJXBo0O).ia6J1v",
            "module": "pNelqfz",
            "filename": "PmRYfUF7fV.go",
            "lineno": 1,
            "in_app": true
          },
          {
            "function": "(*GcPJXBo0O).jqLodorEA6",
            "module": "pNelqfz",
            "filename": "QR8skLy.go",
            "lineno": 1,
            "in_app": true
          },
          {
            "function": "g6qBd3.WriteLevel",
            "module": "pNelqfz",
            "filename": "u9qkupM.go",
            "lineno": 1,
            "in_app": true
          },
          {
            "function": "(*TkPbGafI).WriteLevel",
            "module": "AHvhwz",
            "filename": "vAaFg7om.go",
            "lineno": 1,
            "in_app": true
          },
          {
            "function": "zZKJ7aezE",
            "module": "AHvhwz",
            "filename": "nQS6ZC5.go",
            "lineno": 1,
            "in_app": true
          },
          {
            "function": "Sh0RufN",
            "module": "xojCOs6D",
            "filename": "HY7R3HYUYbp0.go",
            "lineno": 1,
            "in_app": true
          },
          {
            "function": "zZKJ7aezE.func1",
            "module": "AHvhwz",
            "filename": "A8_tfqaEPrO.go",
            "lineno": 1,
            "in_app": true
          },
          {
            "function": "NTSkDRlZS",
            "module": "NkEMIOCQ",
            "filename": "sAof1b2PSs.go",
            "lineno": 1,
            "in_app": true
          }
        ]
      }
    }
  ]
}
```
in this
```json
{
  "exception": [
    {
      "value": "can't continue",
      "stacktrace": {
        "frames": [
          {
            "function": "main",
            "module": "main",
            "filename": "app/cmd/app/main.go",
            "lineno": 56,
            "in_app": true
          },
          {
            "function": "(*Event).Msg",
            "module": "github.com/rs/zerolog",
            "filename": "github.com/rs/zerolog/event.go",
            "lineno": 110,
            "in_app": true
          },
          {
            "function": "(*Event).msg",
            "module": "github.com/rs/zerolog",
            "filename": "github.com/rs/zerolog/event.go",
            "lineno": 151,
            "in_app": true
          },
          {
            "function": "(*Event).write",
            "module": "github.com/rs/zerolog",
            "filename": "github.com/rs/zerolog/event.go",
            "lineno": 80,
            "in_app": true
          },
          {
            "function": "multiLevelWriter.WriteLevel",
            "module": "github.com/rs/zerolog",
            "filename": "github.com/rs/zerolog/writer.go",
            "lineno": 98,
            "in_app": true
          },
          {
            "function": "(*Writer).WriteLevel",
            "module": "github.com/getsentry/sentry-go/zerolog",
            "filename": "github.com/getsentry/sentry-go/zerolog/sentryzerolog.go",
            "lineno": 213,
            "in_app": true
          },
          {
            "function": "parseLogEvent",
            "module": "github.com/getsentry/sentry-go/zerolog",
            "filename": "github.com/getsentry/sentry-go/zerolog/sentryzerolog.go",
            "lineno": 263,
            "in_app": true
          },
          {
            "function": "ObjectEach",
            "module": "github.com/buger/jsonparser",
            "filename": "github.com/buger/jsonparser/parser.go",
            "lineno": 1128,
            "in_app": true
          },
          {
            "function": "parseLogEvent.func1",
            "module": "github.com/getsentry/sentry-go/zerolog",
            "filename": "github.com/getsentry/sentry-go/zerolog/sentryzerolog.go",
            "lineno": 271,
            "in_app": true
          },
          {
            "function": "NewStacktrace",
            "module": "github.com/getsentry/sentry-go",
            "filename": "github.com/getsentry/sentry-go/stacktrace.go",
            "lineno": 29,
            "in_app": true
          }
        ]
      }
    }
  ]
}
```