### PR TITLE
Fix reverse: flag keep

### DIFF
--- a/reverse.go
+++ b/reverse.go
@@ -35,7 +35,7 @@ One can reverse a captured panic stack trace as follows:
 	pkg, args := args[0], args[1:]
 	// We don't actually run `go list -toolexec=garble`; we only use toolexecCmd
 	// to ensure that sharedCache.ListedPackages is filled.
-	_, err := toolexecCmd("list", []string{pkg})
+	_, err := toolexecCmd("list", append(flags, pkg))
 	defer os.RemoveAll(os.Getenv("GARBLE_SHARED"))
 	if err != nil {
 		return err

--- a/testdata/script/reverse.txtar
+++ b/testdata/script/reverse.txtar
@@ -43,6 +43,17 @@ cmp stdout reverse.stdout
 stdin main-literals.stderr
 ! exec garble reverse .
 cmp stdout main-literals.stderr
+
+# https://github.com/burrowers/garble/pull/967
+# Ensure that we can reverse a package with build tag required.
+exec garble build -o tag.bin -tags sometag ./case/tag
+exec ./tag.bin
+cp stderr tag.stderr
+! grep "main.CallerFuncName" tag.stderr
+stdin tag.stderr
+exec garble reverse -tags sometag ./case/tag
+stdout main\.CallerFuncName
+
 -- go.mod --
 module test/main
 
@@ -118,6 +129,23 @@ func printStackTrace(w io.Writer) error {
 	stackLines = append(stackLines[:1], stackLines[3:]...)
 	_, err := w.Write(bytes.Join(stackLines, []byte("\n")))
 	return err
+}
+
+-- case/tag/main.go --
+//go:build sometag
+
+package main
+
+import "runtime"
+
+func main() {
+	println(CallerFuncName())
+}
+
+func CallerFuncName() string {
+	pc, _, _, _ := runtime.Caller(0)
+	fn := runtime.FuncForPC(pc)
+	return fn.Name()
 }
 
 -- reverse.stdout --


### PR DESCRIPTION
This fixes issue caused by 6ac80db0.

`reverse` exits if we have a package that won't build with empty build constraints.