### PR TITLE
Fixed little bag

### DIFF
--- a/main.go
+++ b/main.go
@@ -317,7 +317,8 @@ func mainErr(args []string) error {
 
 		executablePath := args[0]
 		if tool == "link" {
-			modifiedLinkPath, unlock, err := linker.PatchLinker(sharedCache.GoEnv.GOROOT, sharedCache.GoEnv.GOVERSION, sharedCache.CacheDir, sharedTempDir)
+			ver := strings.Fields(sharedCache.GoEnv.GOVERSION)[0]
+			modifiedLinkPath, unlock, err := linker.PatchLinker(sharedCache.GoEnv.GOROOT, ver, sharedCache.CacheDir, sharedTempDir)
 			if err != nil {
 				return fmt.Errorf("cannot get modified linker: %v", err)
 			}


### PR DESCRIPTION
When the GOVERSION variable includes a prefix (e.g., go1.25.3 X:nodwarf5), building a Go project becomes impossible. In my case, Garble throws the following error:
 ```cannot get modified linker: cannot retrieve linker patches: open patches/: file does not exist```

These occurs because version.Lang returns an empty string when version is malformed, like in my case.
To solve this we need to just split the version string and take the first element.