### PR TITLE
garble: fix inconsistcy of anonymous structs in generic functions

### DIFF
--- a/testdata/script/typeparams.txtar
+++ b/testdata/script/typeparams.txtar
@@ -78,3 +78,22 @@ type generic[T any] struct {
 }
 
 type genericAliasNamed genericAlias
+
+func byKeys[T any](m map[string]T) []struct {
+	K string
+	V T
+} {
+	vs := make([]struct {
+		K string
+		V T
+	}, 0, len(m))
+	for k, v := range m {
+		vs = append(vs, struct {
+			K string
+			V T
+		}{k, v})
+	}
+	return vs
+}
+
+var _ = byKeys(map[string]int{"one": 1})

--- a/transformer.go
+++ b/transformer.go
@@ -166,11 +166,18 @@ func recordType(used, origin types.Type, done map[*types.Named]bool, fieldToStru
 		origin := origin.(*types.Struct)
 		for i := range used.NumFields() {
 			field := used.Field(i)
-			fieldToStruct[field.Origin()] = origin
-
+			originField := field.Origin()
+			// Similarly to the Named case above, if we have an anonymous
+			// struct inside a generic function like
+			//
+			//	func foo[T any]() struct { Bar T }
+			//
+			// then we want the hashing to use the original "Bar T".
+			if originField == field || fieldToStruct[originField] == nil {
+				fieldToStruct[originField] = origin
+			}
 			if field.Embedded() {
-				originField := origin.Field(i)
-				recordType(field.Type(), originField.Type(), done, fieldToStruct)
+				recordType(field.Type(), origin.Field(i).Type(), done, fieldToStruct)
 			}
 		}
 	}


### PR DESCRIPTION
Fix: https://github.com/burrowers/garble/issues/1015

Note sure it's complete - binaries are still unusable. 
```
panic: Elt

goroutine 1 [running]:
aaqW7Cn.p31auR[...]({0x102a36fb2?, 0x3})
	JxQLRAo.go:1 +0x154
aaqW7Cn.init()
	Gn8jkfSQx2i.go:1 +0x30
```

cc @mvdan 