### PR TITLE
stabilize hashing for anonymous generic structs

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"go/ast"
+	"go/parser"
 	"go/printer"
 	"go/token"
 	"io/fs"
@@ -140,13 +141,14 @@ func TestScript(t *testing.T) {
 			return false, fmt.Errorf("unknown condition")
 		},
 		Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
-			"sleep":             sleep,
-			"binsubstr":         binsubstr,
-			"bincmp":            bincmp,
-			"generate-literals": generateLiterals,
-			"setenvfile":        setenvfile,
-			"grepfiles":         grepfiles,
-			"setup-go":          setupGo,
+			"sleep":                sleep,
+			"binsubstr":            binsubstr,
+			"bincmp":               bincmp,
+			"generate-literals":    generateLiterals,
+			"setenvfile":           setenvfile,
+			"grepfiles":            grepfiles,
+			"setup-go":             setupGo,
+			"transform-directives": transformDirectivesCmd,
 		},
 		UpdateScripts:       *update,
 		RequireExplicitExec: true,
@@ -399,6 +401,37 @@ func setupGo(ts *testscript.TestScript, neg bool, args []string) {
 	// Remove GOROOT from the environment, as it is unnecessary and gets in the way
 	// when we want to test GOTOOLCHAIN upgrades, which will need different GOROOTs.
 	ts.Setenv("GOROOT", "")
+}
+
+func transformDirectivesCmd(ts *testscript.TestScript, neg bool, args []string) {
+	if neg {
+		ts.Fatalf("unsupported: ! transform-directives")
+	}
+	if len(args) != 3 {
+		ts.Fatalf("usage: transform-directives importpath input.go output.txt")
+	}
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, ts.MkAbs(args[1]), nil, parser.SkipObjectResolution|parser.ParseComments)
+	ts.Check(err)
+
+	pkg := &listedPackage{
+		ImportPath:  args[0],
+		ToObfuscate: true,
+	}
+	pkg.GarbleActionID[0] = 1
+
+	tf := &transformer{curPkg: pkg}
+	ts.Check(tf.transformDirectives(file.Comments))
+
+	outFile := createFile(ts, args[2])
+	defer outFile.Close()
+	for _, group := range file.Comments {
+		for _, comment := range group.List {
+			_, err := fmt.Fprintln(outFile, comment.Text)
+			ts.Check(err)
+		}
+	}
 }
 
 func TestSplitFlagsFromArgs(t *testing.T) {

--- a/reflect.go
+++ b/reflect.go
@@ -557,7 +557,7 @@ func (ri *reflectInspector) obfuscatedObjectName(obj types.Object, parent *types
 	}
 
 	if v, ok := obj.(*types.Var); ok && parent != nil {
-		return hashWithStruct(parent, v)
+		return hashWithStruct(identityStruct(parent, nil), v.Origin())
 	}
 
 	return hashWithPackage(ri.lpkg, obj.Name())

--- a/transformer.go
+++ b/transformer.go
@@ -126,15 +126,42 @@ func computeFieldToStruct(info *types.Info) map[*types.Var]*types.Struct {
 	return fieldToStruct
 }
 
+// identityStruct returns the struct shape which should determine field hashing.
+// For instantiated anonymous generic structs, rebuild a struct from field origins
+// so all equivalent instances hash like their original generic form.
+func identityStruct(used *types.Struct, origin types.Type) *types.Struct {
+	if origin != nil {
+		return origin.(*types.Struct)
+	}
+	fields := make([]*types.Var, used.NumFields())
+	tags := make([]string, used.NumFields())
+	needsClone := false
+	anyTags := false
+	for i := range used.NumFields() {
+		field := used.Field(i)
+		fields[i] = field.Origin()
+		if fields[i] != field {
+			needsClone = true
+		}
+		tags[i] = used.Tag(i)
+		anyTags = anyTags || tags[i] != ""
+	}
+	if !needsClone {
+		return used
+	}
+	if !anyTags {
+		tags = nil
+	}
+	return types.NewStruct(fields, tags)
+}
+
 // recordType visits every reachable type after typechecking a package.
 // Right now, all it does is fill the fieldToStruct map.
 // Since types can be recursive, we need a map to avoid cycles.
 // We only need to track named types as done, as all cycles must use them.
 func recordType(used, origin types.Type, done map[*types.Named]bool, fieldToStruct map[*types.Var]*types.Struct) {
 	used = types.Unalias(used)
-	if origin == nil {
-		origin = used
-	} else {
+	if origin != nil {
 		origin = types.Unalias(origin)
 		// origin may be a [*types.TypeParam].
 		// For now, we haven't found a need to recurse in that case.
@@ -147,7 +174,11 @@ func recordType(used, origin types.Type, done map[*types.Named]bool, fieldToStru
 	type Container interface{ Elem() types.Type }
 	switch used := used.(type) {
 	case Container:
-		recordType(used.Elem(), origin.(Container).Elem(), done, fieldToStruct)
+		if origin == nil {
+			recordType(used.Elem(), nil, done, fieldToStruct)
+		} else {
+			recordType(used.Elem(), origin.(Container).Elem(), done, fieldToStruct)
+		}
 	case *types.Named:
 		if done[used] {
 			return
@@ -163,7 +194,7 @@ func recordType(used, origin types.Type, done map[*types.Named]bool, fieldToStru
 		// Ensure we record the original generic struct, if there is one.
 		recordType(used.Underlying(), used.Origin().Underlying(), done, fieldToStruct)
 	case *types.Struct:
-		origin := origin.(*types.Struct)
+		origin := identityStruct(used, origin)
 		for i := range used.NumFields() {
 			field := used.Field(i)
 			originField := field.Origin()


### PR DESCRIPTION
Canonicalize instantiated anonymous generic structs through their field origins so repeated uses hash to the same field names. Keep reflected field hashing aligned with the same identity shape to avoid mismatched struct types.