### PR TITLE
fix random seed warning

### DIFF
--- a/main.go
+++ b/main.go
@@ -518,7 +518,7 @@ func (f *seedFlag) Set(s string) error {
 	if s == "random" {
 		f.random = true // to show the random seed we chose
 
-		f.bytes = make([]byte, 16) // random 128 bit seed
+		f.bytes = make([]byte, 8) // random 64 bit seed
 		if _, err := cryptorand.Read(f.bytes); err != nil {
 			return fmt.Errorf("error generating random seed: %v", err)
 		}

--- a/testdata/script/seed.txtar
+++ b/testdata/script/seed.txtar
@@ -64,6 +64,7 @@ cp stderr importedpkg-seed-static-2
 # Use a random seed, which should always trigger a full build.
 exec garble -seed=random build -v
 stderr -count=1 '^-seed chosen at random: .+'
+! stderr 'warning: -seed only uses the first 8 bytes'
 stderr -count=1 '^runtime$'
 stderr -count=1 '^test/main$'
 exec ./main$exe
@@ -80,6 +81,7 @@ cp main$exe main_random$exe
 rm main$exe
 exec garble -seed=random build -v
 stderr .
+! stderr 'warning: -seed only uses the first 8 bytes'
 ! bincmp main$exe main_random$exe
 
 exec ./main$exe test/main/imported


### PR DESCRIPTION
  Fixes repeated warnings when using `-seed=random`.

  `-seed=random` currently generates a 16-byte seed, but garble only uses the first 8 bytes. Since PR #1010 added a warning for seeds longer than 8 bytes, the generated random seed is propagated to toolexec subprocesses and each
  package can emit:

  ```text
  warning: -seed only uses the first 8 bytes, ignoring 8 extra bytes

  For example, even a minimal main package can print dozens of these warnings during a verbose build.

  This change makes -seed=random generate 8 bytes directly, matching the length that garble actually uses for deterministic obfuscation. The existing random-seed behavior is preserved: each build still receives a random seed,
  but toolexec subprocesses no longer warn about ignored bytes.

  The seed script test now also asserts that -seed=random does not emit the warning.

  Tested with:

  go test -run '^TestScript/seed$'

  I also ran go test ./...; unrelated tests failed locally due to garble -literals build std being killed and a timeout while downloading golang.org/toolchain from proxy.golang.org.