### PR TITLE
limit the build, run-time, and testing cost of `-literals`

### DIFF
--- a/internal/literals/fuzz_test.go
+++ b/internal/literals/fuzz_test.go
@@ -45,7 +45,7 @@ func FuzzObfuscate(f *testing.F) {
 	f.Add("long_enough_string", initialRandSeed)
 	f.Add("binary_\x00\x01\x02", initialRandSeed)
 	f.Add("whitespace    \n\t\t", initialRandSeed)
-	f.Add(strings.Repeat("x", (2<<10)+1), initialRandSeed) // past maxSize
+	f.Add(strings.Repeat("x", (2<<10)+1), initialRandSeed) // past MaxSize
 
 	tdir := f.TempDir()
 	var tdirCounter atomic.Int64

--- a/internal/literals/literals.go
+++ b/internal/literals/literals.go
@@ -21,10 +21,12 @@ import (
 // moderate, this also decreases the likelihood for performance slowdowns.
 const MinSize = 8
 
-// maxSize is the upper limit of the size of string-like literals
-// which we will obfuscate with any of the available obfuscators.
-// Beyond that we apply only a subset of obfuscators which are guaranteed to run efficiently.
-const maxSize = 2 << 10 // KiB
+// MaxSize is the upper limit of the size of string-like literals we will obfuscate.
+const MaxSize = 2 << 10 // 2 KiB
+
+// MaxSizeExpensive is the upper limit for using expensive obfuscators (split, seed).
+// Above this size, only cheap obfuscators are used.
+const MaxSizeExpensive = 256
 
 const (
 	// minStringJunkBytes defines the minimum number of junk bytes to prepend or append during string obfuscation.
@@ -83,7 +85,7 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 
 		if typeAndValue.Type == types.Typ[types.String] && typeAndValue.Value != nil {
 			value := constant.StringVal(typeAndValue.Value)
-			if len(value) < MinSize {
+			if len(value) < MinSize || len(value) > MaxSize {
 				return true
 			}
 
@@ -143,7 +145,7 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 //
 // If the input node cannot be obfuscated nil is returned.
 func handleCompositeLiteral(obfRand *obfRand, isPointer bool, node *ast.CompositeLit, info *types.Info) ast.Node {
-	if len(node.Elts) < MinSize {
+	if len(node.Elts) < MinSize || len(node.Elts) > MaxSize {
 		return nil
 	}
 
@@ -357,9 +359,11 @@ func obfuscateByteArray(obfRand *obfRand, isPointer bool, data []byte, length in
 }
 
 func getNextObfuscator(obfRand *obfRand, size int) obfuscator {
-	if size <= maxSize {
-		return obfRand.nextObfuscator()
-	} else {
-		return obfRand.nextLinearTimeObfuscator()
+	if size < MinSize || size > MaxSize {
+		panic(fmt.Sprintf("getNextObfuscator called with size %d outside [%d, %d]", size, MinSize, MaxSize))
 	}
+	if size <= MaxSizeExpensive {
+		return obfRand.nextObfuscator()
+	}
+	return obfRand.nextCheapObfuscator()
 }

--- a/internal/literals/obfuscators.go
+++ b/internal/literals/obfuscators.go
@@ -60,20 +60,20 @@ type obfuscator interface {
 }
 
 var (
-	simpleObfuscator = simple{}
-
-	// Obfuscators contains all types which implement the obfuscator Interface
+	// Obfuscators contains all types which implement the obfuscator Interface.
 	Obfuscators = []obfuscator{
-		simpleObfuscator,
+		simple{},
 		swap{},
 		split{},
 		shuffle{},
 		seed{},
 	}
 
-	// LinearTimeObfuscators contains all types which implement the obfuscator Interface and can safely be used on large literals
-	LinearTimeObfuscators = []obfuscator{
-		simpleObfuscator,
+	// CheapObfuscators contains obfuscators safe to use on large literals.
+	// The expensive obfuscators scale poorly, so they are excluded here.
+	CheapObfuscators = []obfuscator{
+		simple{},
+		swap{},
 	}
 
 	TestObfuscator         string
@@ -268,11 +268,11 @@ func (r *obfRand) nextObfuscator() obfuscator {
 	return Obfuscators[r.Intn(len(Obfuscators))]
 }
 
-func (r *obfRand) nextLinearTimeObfuscator() obfuscator {
+func (r *obfRand) nextCheapObfuscator() obfuscator {
 	if r.testObfuscator != nil {
 		return r.testObfuscator
 	}
-	return LinearTimeObfuscators[r.Intn(len(LinearTimeObfuscators))]
+	return CheapObfuscators[r.Intn(len(CheapObfuscators))]
 }
 
 func newObfRand(rand *mathrand.Rand, file *ast.File, nameFunc NameProviderFunc) *obfRand {

--- a/main_test.go
+++ b/main_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rogpeppe/go-internal/testscript"
 
 	ah "mvdan.cc/garble/internal/asthelper"
+	"mvdan.cc/garble/internal/literals"
 )
 
 var proxyURL string
@@ -248,23 +249,10 @@ func bincmp(ts *testscript.TestScript, neg bool, args []string) {
 
 var testRand = mathrand.New(mathrand.NewSource(time.Now().UnixNano()))
 
-func generateStringLit(minSize int) *ast.BasicLit {
-	buffer := make([]byte, minSize)
-	_, err := testRand.Read(buffer)
-	if err != nil {
-		panic(err)
-	}
+const uniqueLitString = "garble_unique_string"
 
-	return ah.StringLit(string(buffer) + "a_unique_string_that_is_part_of_all_extra_literals")
-}
-
-// generateLiterals creates a new source code file with a few random literals inside.
-// All literals contain the string "a_unique_string_that_is_part_of_all_extra_literals"
-// so we can later check if they are all obfuscated by looking for this substring.
-// The code is designed such that the Go compiler does not optimize away the literals,
-// which would destroy the test.
-// This is achieved by defining a global variable `var x = ""` and an `init` function
-// which appends all literals to `x`.
+// generateLiterals creates a source file with random string literals appended
+// to a global var in init, preventing the compiler from optimizing them away.
 func generateLiterals(ts *testscript.TestScript, neg bool, args []string) {
 	if neg {
 		ts.Fatalf("unsupported: ! generate-literals")
@@ -290,29 +278,32 @@ func generateLiterals(ts *testscript.TestScript, neg bool, args []string) {
 
 	var statements []ast.Stmt
 
-	// Assignments which append 100 random small literals to x: `x += "the_small_random_literal"`
+	// 100 literals up to MaxSize, all containing uniqueLitString.
 	for range 100 {
+		randSize := testRand.Intn(literals.MaxSize - len(uniqueLitString) + 1)
+		buffer := make([]byte, randSize)
+		testRand.Read(buffer)
 		statements = append(
 			statements,
 			&ast.AssignStmt{
 				Lhs: []ast.Expr{ast.NewIdent("x")},
 				Tok: token.ADD_ASSIGN,
-				Rhs: []ast.Expr{generateStringLit(1 + testRand.Intn(255))},
+				Rhs: []ast.Expr{ah.StringLit(string(buffer) + uniqueLitString)},
 			},
 		)
 	}
 
-	// Assignments which append 5 random huge literals to x: `x += "the_huge_random_literal"`
-	// We add huge literals to make sure we obfuscate them fast.
-	// 5 * 128KiB is large enough that it would take a very, very long time
-	// to obfuscate those literals if too complex obfuscators are used.
+	// 5 huge literals past MaxSize, without uniqueLitString; not obfuscated.
 	for range 5 {
+		size := literals.MaxSize + 1 + testRand.Intn(128<<10)
+		buffer := make([]byte, size)
+		testRand.Read(buffer)
 		statements = append(
 			statements,
 			&ast.AssignStmt{
 				Lhs: []ast.Expr{ast.NewIdent("x")},
 				Tok: token.ADD_ASSIGN,
-				Rhs: []ast.Expr{generateStringLit(128 << 10)},
+				Rhs: []ast.Expr{ah.StringLit(string(buffer))},
 			},
 		)
 	}

--- a/scripts/bench_literals.go
+++ b/scripts/bench_literals.go
@@ -1,160 +1,289 @@
-// This script generate benchmarks for performance analysis of individual obfuscator literals.
-// Note that only the speed of obfuscated methods is measured, initialization cost or build speed are not measured.
+// Copyright (c) 2020, The Garble Authors.
+// See LICENSE for licensing information.
 
 //go:build ignore
 
+// bench_literals benchmarks the build and run-time impact of each literal
+// obfuscator across a range of string sizes.
+//
+// It generates one Go module per string size, each containing many strings of
+// that size. For each obfuscator, it measures:
+//   - Build time: time to "garble -literals build" versus "go build"
+//   - Run time: time to execute the resulting binary (strings are decrypted at init)
+//
+// The garble binary is built with the garble_testing tag to allow forcing a
+// specific obfuscator via GARBLE_TEST_LITERALS_OBFUSCATOR_MAP.
+//
+// Each build iteration writes a unique dummy var to bust the build cache
+// without rebuilding the entire runtime. A 5s timeout kills any build or run
+// that takes too long, reporting "timeout" on stderr and skipping.
+//
+// Output is in Go benchmark format, compatible with benchstat.
+//
+// Usage: go run ./scripts/bench_literals.go [-count N] [-timeout duration] [-run regexp]
+//
+// Then compare all obfuscators against the go baseline with:
+//
+//	benchstat -col /obf results.txt
+//
+// Or, if you obtained all results but want to show just one:
+//
+//	benchstat -col /obf -filter '/obf:(go OR swap)' out
 package main
 
 import (
-	_ "embed"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"flag"
 	"fmt"
-	"log"
+	mathrand "math/rand/v2"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
-	"runtime"
-	"strconv"
+	"regexp"
 	"strings"
-
-	"mvdan.cc/garble/internal/literals"
+	"syscall"
+	"time"
 )
 
-const (
-	minDataLen      = 8
-	maxDataLen      = 64
-	stepDataLen     = 4
-	dataCountPerLen = 10
-	moduleName      = "test/literals"
-	garbleSeed      = "o9WDTZ4CN4w"
+var rng *mathrand.ChaCha8
 
-	// For benchmarking individual obfuscators, we use package=obfuscator mapping
-	// and add a prefix to package name to make sure there are no collisions with system packages.
-	packagePrefix = "literals_bench_"
-)
-
-func generateRunSrc() string {
-	var sb strings.Builder
-
-	sb.WriteString(`
-var alwaysFalseFlag = false
-
-func noop(i any) {
-	if alwaysFalseFlag {
-		println(i)
-	}	
-}
-
-func Run() {
-`)
-
-	dataStr := strings.Repeat("X", maxDataLen)
-	dataBytes := make([]string, maxDataLen)
-	for i := 0; i < len(dataBytes); i++ {
-		dataBytes[i] = strconv.Itoa(i)
-	}
-
-	for dataLen := minDataLen; dataLen <= maxDataLen; dataLen += stepDataLen {
-		for y := 0; y < dataCountPerLen; y++ {
-			fmt.Fprintf(&sb, "\tnoop(%q)\n", dataStr[:dataLen])
-			fmt.Fprintf(&sb, "\tnoop([]byte{%s})\n", strings.Join(dataBytes[:dataLen], ", "))
-		}
-	}
-
-	sb.WriteString("}\n")
-	return sb.String()
-}
-
-func buildTestGarble(tdir string) string {
-	garbleBin := filepath.Join(tdir, "garble")
-	if runtime.GOOS == "windows" {
-		garbleBin += ".exe"
-	}
-
-	output, err := exec.Command("go", "build", "-tags", "garble_testing", "-o="+garbleBin).CombinedOutput()
-	if err != nil {
-		log.Fatalf("garble build failed: %v\n%s", err, string(output))
-	}
-
-	return garbleBin
-}
-
-func handle(err error) {
-	if err != nil {
+func init() {
+	var seed [32]byte
+	if _, err := rand.Read(seed[:]); err != nil {
 		panic(err)
 	}
+	rng = mathrand.NewChaCha8(seed)
 }
 
-func writeDateFile(tdir, obfName, src string) {
-	pkgName := packagePrefix + obfName
+var (
+	count     = flag.Int("count", 1, "number of iterations for each benchmark")
+	timeout   = flag.Duration("timeout", 5*time.Second, "timeout per build or run invocation")
+	runFilter = flag.String("run", "", "regexp to filter which obfuscators to run (always includes go baseline)")
+)
 
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "package %s\n\n", pkgName)
-	sb.WriteString(src)
-
-	dir := filepath.Join(tdir, pkgName)
-	handle(os.MkdirAll(dir, 0o777))
-	handle(os.WriteFile(filepath.Join(dir, "data.go"), []byte(sb.String()), 0o777))
+// obfuscatorNames maps index to name, matching internal/literals/obfuscators.go.
+var obfuscatorNames = []string{
+	"simple",
+	"swap",
+	"split",
+	"shuffle",
+	"seed",
 }
 
-func writeTestFile(dir, obfName string) {
-	var sb strings.Builder
-	sb.WriteString(`package main
-import "testing"
-`)
-	pkgName := packagePrefix + obfName
-	fmt.Fprintf(&sb, "import %q\n", moduleName+"/"+pkgName)
-	fmt.Fprintf(&sb, `func Benchmark%s(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		%s.Run()		
-	}
-}
-`, strings.ToUpper(obfName[:1])+obfName[1:], pkgName)
-
-	handle(os.WriteFile(filepath.Join(dir, obfName+"_test.go"), []byte(sb.String()), 0o777))
+// stringSizes to benchmark, from just above MinSize (8) to the maxSize limit (2048).
+var stringSizes = []int{
+	16, 64, 256, 1024, 2048,
 }
 
 func main() {
-	tdir, err := os.MkdirTemp("", "literals-bench*")
+	flag.Parse()
+
+	garbleDir, err := os.Getwd()
 	if err != nil {
-		log.Fatalf("create temp directory failed: %v", err)
-	}
-	defer os.RemoveAll(tdir)
-
-	if err := os.WriteFile(filepath.Join(tdir, "go.mod"), []byte("module "+moduleName), 0o777); err != nil {
-		log.Fatalf("write go.mod failed: %v", err)
+		fatal("getwd: %v", err)
 	}
 
-	runSrc := generateRunSrc()
-	writeTest := func(name string) {
-		writeDateFile(tdir, name, runSrc)
-		writeTestFile(tdir, name)
+	tmpDir, err := os.MkdirTemp("", "garble-bench-literals-*")
+	if err != nil {
+		fatal("mkdtemp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Build garble with garble_testing tag.
+	garbleBin := filepath.Join(tmpDir, "garble")
+	fmt.Fprintf(os.Stderr, "building garble with garble_testing tag...\n")
+	runCmdNoTimeout(garbleDir, nil, "go", "build", "-tags=garble_testing", "-o", garbleBin, ".")
+
+	// Generate one module per string size.
+	sizeDirs := make(map[int]string)
+	for _, size := range stringSizes {
+		dir := filepath.Join(tmpDir, fmt.Sprintf("size_%d", size))
+		must(os.MkdirAll(dir, 0o755))
+		writeTestModule(dir, size)
+		sizeDirs[size] = dir
 	}
 
-	var packageToObfuscatorIndex []string
-	for i, obf := range literals.Obfuscators {
-		obfName := reflect.TypeOf(obf).Name()
-		writeTest(obfName)
-		packageToObfuscatorIndex = append(packageToObfuscatorIndex, fmt.Sprintf(packagePrefix+"%s=%d", obfName, i))
-	}
-	writeTest("all")
+	// Warm the garble cache by building one program.
+	// Garble caches transformed stdlib, so the first build is much slower.
+	fmt.Fprintf(os.Stderr, "warming garble cache...\n")
+	warmEnv := []string{"GARBLE_TEST_LITERALS_OBFUSCATOR_MAP=main=0"}
+	warmBin := filepath.Join(tmpDir, "warmup_bin")
+	runCmdNoTimeout(sizeDirs[16], warmEnv, garbleBin, "-literals", "build", "-o", warmBin, ".")
 
-	garbleBin := buildTestGarble(tdir)
-	args := append([]string{"-seed", garbleSeed, "-literals", "test", "-bench"}, os.Args[1:]...)
-	cmd := exec.Command(garbleBin, args...)
-	cmd.Env = append(cmd.Environ(),
-		// Explicitly specify package for obfuscation to avoid affecting testing package.
-		"GOGARBLE="+moduleName,
-		"GARBLE_TEST_LITERALS_OBFUSCATOR_MAP="+strings.Join(packageToObfuscatorIndex, ","),
-	)
-	cmd.Dir = tdir
-	cmd.Stdout = os.Stdout
+	// Baseline: go build.
+	for _, size := range stringSizes {
+		bin := filepath.Join(tmpDir, fmt.Sprintf("go_%d_bin", size))
+		benchAndPrint("Build/obf=go", size, sizeDirs[size], nil, "go", "build", "-o", bin, ".")
+	}
+	for _, size := range stringSizes {
+		bin := filepath.Join(tmpDir, fmt.Sprintf("go_%d_bin", size))
+		benchRunAndPrint("Run/obf=go", size, bin)
+	}
+
+	var filterRe *regexp.Regexp
+	if *runFilter != "" {
+		var err error
+		filterRe, err = regexp.Compile(*runFilter)
+		if err != nil {
+			fatal("bad -run regexp: %v", err)
+		}
+	}
+
+	// Each obfuscator.
+	for idx, name := range obfuscatorNames {
+		if filterRe != nil && !filterRe.MatchString(name) {
+			fmt.Fprintf(os.Stderr, "skipping obfuscator %s (filtered by -run)\n", name)
+			continue
+		}
+		env := []string{fmt.Sprintf("GARBLE_TEST_LITERALS_OBFUSCATOR_MAP=main=%d", idx)}
+		for _, size := range stringSizes {
+			bin := filepath.Join(tmpDir, fmt.Sprintf("garble_%s_%d_bin", name, size))
+			benchAndPrint("Build/obf="+name, size, sizeDirs[size], env, garbleBin, "-literals", "build", "-o", bin, ".")
+		}
+		for _, size := range stringSizes {
+			bin := filepath.Join(tmpDir, fmt.Sprintf("garble_%s_%d_bin", name, size))
+			benchRunAndPrint("Run/obf="+name, size, bin)
+		}
+	}
+}
+
+// benchAndPrint runs the build command *count times, printing one benchstat line per iteration.
+func benchAndPrint(benchName string, size int, dir string, extraEnv []string, args ...string) {
+	name := fmt.Sprintf("Benchmark%s/%dB", benchName, size)
+	timedOut := false
+	for range *count {
+		if timedOut {
+			break
+		}
+		// Write a unique entrypoint file each iteration to bust the build cache
+		// without rebuilding the entire runtime.
+		entry := fmt.Sprintf("package main\n\nvar _benchIter uint64 = %d\n", rng.Uint64())
+		must(os.WriteFile(filepath.Join(dir, "bench_iter.go"), []byte(entry), 0o644))
+
+		d, ok := runCmdWithTimeout(dir, extraEnv, args[0], args[1:]...)
+		if !ok {
+			fmt.Printf("%s 1 %d ns/op\n", name, timeout.Nanoseconds())
+			fmt.Fprintf(os.Stderr, "    ^ timed out: %s %s\n", args[0], strings.Join(args[1:], " "))
+			timedOut = true
+			continue
+		}
+		fmt.Printf("%s 1 %d ns/op\n", name, d.Nanoseconds())
+	}
+}
+
+// benchRunAndPrint runs the binary *count times, printing one benchstat line per iteration.
+func benchRunAndPrint(benchName string, size int, bin string) {
+	name := fmt.Sprintf("Benchmark%s/%dB", benchName, size)
+	if _, err := os.Stat(bin); err != nil {
+		// Binary wasn't built (build timed out).
+		fmt.Printf("%s 1 %d ns/op\n", name, timeout.Nanoseconds())
+		fmt.Fprintf(os.Stderr, "    ^ binary not built (build timed out)\n")
+		return
+	}
+	for range *count {
+		d, ok := runCmdWithTimeout("", nil, bin)
+		if !ok {
+			fmt.Printf("%s 1 %d ns/op\n", name, timeout.Nanoseconds())
+			fmt.Fprintf(os.Stderr, "    ^ timed out: %s\n", bin)
+			return
+		}
+		fmt.Printf("%s 1 %d ns/op\n", name, d.Nanoseconds())
+	}
+}
+
+// runCmdWithTimeout runs the command with the configured timeout.
+// It returns the elapsed time and true on success, or zero and false on timeout.
+// The command is started in its own process group so that on timeout,
+// the entire tree (including child processes like subcompilers) is killed.
+func runCmdWithTimeout(dir string, extraEnv []string, name string, args ...string) (time.Duration, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, name, args...)
+
+	// Kill the entire process group, not just the leader.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Env = append(os.Environ(), extraEnv...)
+	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 
-	if err := cmd.Run(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			os.Exit(exitErr.ExitCode())
-		}
-		log.Fatalf("run garble test failed: %v", err)
+	start := time.Now()
+	err := cmd.Run()
+	elapsed := time.Since(start)
+
+	if ctx.Err() != nil {
+		return 0, false
 	}
+	if err != nil {
+		fatal("command %s %v failed: %v", name, args, err)
+	}
+	return elapsed, true
+}
+
+// runCmdNoTimeout runs a command without any timeout (used for setup steps).
+func runCmdNoTimeout(dir string, extraEnv []string, name string, args ...string) {
+	cmd := exec.Command(name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Env = append(os.Environ(), extraEnv...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fatal("command %s %v failed: %v", name, args, err)
+	}
+}
+
+// numStrings is the number of strings per size in each test program.
+// High enough to amortize per-build overhead and produce stable timings,
+// low enough to keep individual builds fast.
+const numStrings = 20
+
+func writeTestModule(dir string, stringSize int) {
+	goMod := "module test/bench\n\ngo 1.26\n"
+	must(os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644))
+
+	var b strings.Builder
+	b.WriteString("package main\n\nimport \"os\"\n\n")
+
+	for i := range numStrings {
+		str := randomHex(stringSize)
+		fmt.Fprintf(&b, "var s%d = %q\n", i, str)
+	}
+
+	b.WriteString("\nfunc main() {\n")
+	b.WriteString("\tf, _ := os.Create(os.DevNull)\n")
+	for i := range numStrings {
+		fmt.Fprintf(&b, "\tf.WriteString(s%d)\n", i)
+	}
+	b.WriteString("\tf.Close()\n")
+	b.WriteString("}\n")
+
+	must(os.WriteFile(filepath.Join(dir, "main.go"), []byte(b.String()), 0o644))
+}
+
+func randomHex(n int) string {
+	raw := make([]byte, (n+1)/2)
+	rng.Read(raw)
+	return hex.EncodeToString(raw)[:n]
+}
+
+func must(err error) {
+	if err != nil {
+		fatal("%v", err)
+	}
+}
+
+func fatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "error: "+format+"\n", args...)
+	os.Exit(1)
 }

--- a/testdata/script/literals.txtar
+++ b/testdata/script/literals.txtar
@@ -55,10 +55,6 @@ grep '^\s+type \w+ func\(byte\) \w+$' debug1/garbled/test/main/extra_literals.go
 
 # Check external keys
 grep 'garbleExternalKey' debug1/garbled/test/main/extra_literals.go
-
-# Finally, sanity check that we can build all of std with -literals.
-# Analogous to gogarble.txt.
-exec garble -literals build std
 -- go.mod --
 module test/main
 

--- a/testdata/script/literals.txtar
+++ b/testdata/script/literals.txtar
@@ -27,13 +27,13 @@ generate-literals extra_literals.go
 
 # ensure we find the extra literals in an unobfuscated build
 go build
-binsubstr main$exe 'a_unique_string_that_is_part_of_all_extra_literals'
+binsubstr main$exe 'garble_unique_string'
 
 # ensure we don't find the extra literals in an obfuscated build
 exec garble -literals -debugdir=debug1 build
 exec ./main$exe
 cmp stderr main.stderr
-! binsubstr main$exe 'a_unique_string_that_is_part_of_all_extra_literals'
+! binsubstr main$exe 'garble_unique_string'
 
 # Check obfuscators.
 


### PR DESCRIPTION
(see commit messages - please do not squash)

Fixes #928.