### PR TITLE
do not create ./build in cwd when cache init is skipped

### DIFF
--- a/main.go
+++ b/main.go
@@ -261,7 +261,7 @@ func mainErr(args []string) error {
 				fmt.Fprintf(os.Stderr, "could not clean up GARBLE_SHARED: %v\n", err)
 			}
 			// skip the trim if we didn't even start a build
-			if sharedCache != nil {
+			if sharedCache != nil && sharedCache.CacheDir != "" {
 				fsCache, err := openCache()
 				if err == nil {
 					err = fsCache.Trim()

--- a/testdata/script/goversion.txtar
+++ b/testdata/script/goversion.txtar
@@ -39,6 +39,7 @@ env GARBLE_TEST_GOVERSION='go1.38.2'
 env TOOLCHAIN_GOVERSION='go1.38.2'
 ! exec garble build
 stderr 'Go version "go1\.38\.2" is too new; Go linker patches aren''t available for go1\.27 or later yet'
+! exists build
 
 # We should accept custom devel strings.
 env TOOLCHAIN_GOVERSION='go1.26.0-somecustomversion'

--- a/testdata/script/goversion.txtar
+++ b/testdata/script/goversion.txtar
@@ -39,6 +39,7 @@ env GARBLE_TEST_GOVERSION='go1.38.2'
 env TOOLCHAIN_GOVERSION='go1.38.2'
 ! exec garble build
 stderr 'Go version "go1\.38\.2" is too new; Go linker patches aren''t available for go1\.27 or later yet'
+# Ensure we don't create a cache directory in the current dir.
 ! exists build
 
 # We should accept custom devel strings.


### PR DESCRIPTION
Fixes #995.

sharedCache is allocated at the top of toolexecCmd, before
goVersionOK and before the GARBLE_CACHE / UserCacheDir resolution
that sets sharedCache.CacheDir. The defer in mainErr's build/test/run
branch guards on `sharedCache != nil`, which is too weak: any early
return between the allocation and the CacheDir assignment leaves
CacheDir empty, and openCache then does filepath.Join("", "build")
and MkdirAll's a relative "build" in the current directory. Once
cache.Open sees that path it lays out the 00..ff shards and trim.txt.

Tighten the guard so the trim is skipped unless the cache was fully
initialized, and assert in testdata/script/goversion.txtar that no
build directory is left behind on the too-new-version path.