### PR TITLE
fix: mismatched cross-package field hashes for anonymous generic structs

### DIFF
--- a/bundled_typeutil.go
+++ b/bundled_typeutil.go
@@ -38,8 +38,9 @@ func (h typeutil_Hasher) Hash(t types.Type) uint32 {
 // typeParamIDs assigns deterministic traversal-local IDs to free type params,
 // making hashes stable across alpha-renaming in equivalent generic contexts.
 type typeutil_hasher struct {
-	inGenericSig bool
-	typeParamIDs map[*types.TypeParam]uint32
+	inGenericSig  bool
+	inStructField bool // NOTE(garble): skip type args from named types when hashing struct field types
+	typeParamIDs  map[*types.TypeParam]uint32
 }
 
 // hashString computes the Fowler–Noll–Vo hash of s.
@@ -78,7 +79,10 @@ func (h typeutil_hasher) hash(t types.Type) uint32 {
 			// NOTE(garble): we must not hash struct field tags, as they do not affect type identity.
 			// hash += typeutil_hashString(t.Tag(i))
 			hash += typeutil_hashString(f.Name()) // (ignore f.Pkg)
-			hash += h.hash(f.Type())
+			// NOTE(garble): strip type args from named types to keep hashes stable across packages.
+			h2 := h
+			h2.inStructField = true
+			hash += h2.hash(f.Type())
 		}
 		return hash
 
@@ -139,9 +143,12 @@ func (h typeutil_hasher) hash(t types.Type) uint32 {
 
 	case *types.Named:
 		hash := h.hashTypeName(t.Obj())
-		targs := t.TypeArgs()
-		for targ := range targs.Types() {
-			hash += 2 * h.hash(targ)
+		// NOTE(garble): skip type args for struct fields; see inStructField.
+		if !h.inStructField {
+			targs := t.TypeArgs()
+			for targ := range targs.Types() {
+				hash += 2 * h.hash(targ)
+			}
 		}
 		return hash
 

--- a/testdata/script/typeparams.txtar
+++ b/testdata/script/typeparams.txtar
@@ -27,6 +27,8 @@ func main() {
 	e := lib.Entry[string, int]{Key: "foo", Data: 123}
 	r := lib.Load[string, int](e)
 	_ = r.Data
+
+	_ = lib.SelectWhere.Users.Name
 }
 
 func GenericFunc[GenericParamA, B any](x GenericParamA, y B) {}
@@ -118,3 +120,13 @@ type Entry[Key ~string, Data any] struct {
 func Load[Key ~string, Data any](e Entry[Key, Data]) Result[Data] {
 	return Result[Data]{Data: e.Data}
 }
+
+type Filter[Q any] struct{ Name Q }
+
+func Where[Q any]() struct {
+	Users Filter[Q]
+} {
+	return struct{ Users Filter[Q] }{}
+}
+
+var SelectWhere = Where[int]()


### PR DESCRIPTION
fixes #1041 

This PR strips generic type arguments from the struct field type hash so that anonymous structs returned by generic functions produce consistent obfuscated field names across packages.

Prior to this, the defining package hashed field types with type parameters (e.g., Filter[Q]). Importing packages hashed with concrete types from export data (e.g., Filter[int]), producing different obfuscated field names and breaking the build, as in the linked issue.