### PR TITLE
Feature: Command-line option to select literal obfuscators

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Emmanuel Chee-zaram Okeke <ecokeke21@gmail.com>
 Golo Roden <golo.roden@thenativeweb.io>
 NHAS <jordanatararimu@gmail.com>
 Nicholas Jones <me@nicholasjon.es>
+Nicolaas Weideman <jklncylii@mozmail.com>
 Paul Scheduikat <luantak@pm.me>
 Zachary Wasserman <zachwass2000@gmail.com>
 pagran <pagran@protonmail.com>

--- a/hash.go
+++ b/hash.go
@@ -130,6 +130,8 @@ func appendFlags(w io.Writer, forBuildHash bool) {
 	if flagLiterals {
 		io.WriteString(w, " -literals")
 	}
+	io.WriteString(w, " -literalObfuscators=")
+	io.WriteString(w, flagLiteralObfuscators)
 	if flagTiny {
 		io.WriteString(w, " -tiny")
 	}

--- a/internal/literals/literals.go
+++ b/internal/literals/literals.go
@@ -39,8 +39,8 @@ const (
 type NameProviderFunc func(rand *mathrand.Rand, baseName string) string
 
 // Obfuscate replaces literals with obfuscated anonymous functions.
-func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkStrings map[*types.Var]string, nameFunc NameProviderFunc) *ast.File {
-	or := newObfRand(rand, file, nameFunc)
+func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, obfuscators []Obfuscator, linkStrings map[*types.Var]string, nameFunc NameProviderFunc) *ast.File {
+	or := newObfRand(rand, file, nameFunc, obfuscators)
 	pre := func(cursor *astutil.Cursor) bool {
 		switch node := cursor.Node().(type) {
 		case *ast.FuncDecl:
@@ -358,15 +358,15 @@ func obfuscateByteArray(or *obfRand, isPointer bool, data []byte, length int64) 
 	return ah.LambdaCall(params, arrayType, block, args)
 }
 
-func (or *obfRand) pickObfuscator(size int) obfuscator {
+func (or *obfRand) pickObfuscator(size int) Obfuscator {
 	if size < MinSize || size > MaxSize {
 		panic(fmt.Sprintf("nextObfuscator called with size %d outside [%d, %d]", size, MinSize, MaxSize))
 	}
 	if or.testObfuscator != nil {
 		return or.testObfuscator
 	}
-	if size <= MaxSizeExpensive {
-		return Obfuscators[or.rnd.Intn(len(Obfuscators))]
+	if size <= MaxSizeExpensive || len(or.cheapLiteralObfuscators) == 0 {
+		return or.literalObfuscators[or.rnd.Intn(len(or.literalObfuscators))]
 	}
-	return CheapObfuscators[or.rnd.Intn(len(CheapObfuscators))]
+	return or.cheapLiteralObfuscators[or.rnd.Intn(len(or.cheapLiteralObfuscators))]
 }

--- a/internal/literals/obfuscators.go
+++ b/internal/literals/obfuscators.go
@@ -54,30 +54,31 @@ func (k *externalKey) IsUsed() bool {
 	return k.refs > 0
 }
 
-// obfuscator takes a byte slice and converts it to a ast.BlockStmt
-type obfuscator interface {
-	obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*externalKey) *ast.BlockStmt
+// Obfuscator takes a byte slice and converts it to a ast.BlockStmt
+type Obfuscator interface {
+	obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*externalKey) *ast.BlockStmt;
+	isCheap() bool
 }
 
 var (
-	// Obfuscators contains all types which implement the obfuscator Interface.
-	Obfuscators = []obfuscator{
-		simple{},
-		swap{},
-		split{},
-		shuffle{},
-		seed{},
+	// Obfuscators contains all types which implement the Obfuscator Interface.
+	Obfuscators = map[string]Obfuscator{
+		"simple": simple{},
+		"swap": swap{},
+		"split": split{},
+		"shuffle": shuffle{},
+		"seed": seed{},
 	}
 
 	// CheapObfuscators contains obfuscators safe to use on large literals.
 	// The expensive obfuscators scale poorly, so they are excluded here.
-	CheapObfuscators = []obfuscator{
-		simple{},
-		swap{},
+	CheapObfuscators = map[string]Obfuscator{
+		"simple": simple{},
+		"swap": swap{},
 	}
 
 	TestObfuscator         string
-	testPkgToObfuscatorMap map[string]obfuscator
+	testPkgToObfuscatorMap map[string]Obfuscator
 )
 
 func genRandIntSlice(obfRand *mathrand.Rand, max, count int) []int {
@@ -257,11 +258,19 @@ func byteLitWithExtKey(rand *mathrand.Rand, val byte, extKeys []*externalKey, ex
 type obfRand struct {
 	rnd *mathrand.Rand
 
-	testObfuscator  obfuscator
+	testObfuscator  Obfuscator
 	proxyDispatcher *proxyDispatcher
+	literalObfuscators []Obfuscator
+	cheapLiteralObfuscators []Obfuscator
 }
 
-func newObfRand(rand *mathrand.Rand, file *ast.File, nameFunc NameProviderFunc) *obfRand {
+func newObfRand(rand *mathrand.Rand, file *ast.File, nameFunc NameProviderFunc, obfuscators []Obfuscator) *obfRand {
 	testObf := testPkgToObfuscatorMap[file.Name.Name]
-	return &obfRand{rand, testObf, newProxyDispatcher(rand, nameFunc)}
+	var cheapLiteralObfuscators []Obfuscator;
+	for _, o := range obfuscators {
+		if o.isCheap() {
+			cheapLiteralObfuscators = append(cheapLiteralObfuscators, o);
+		}
+	}
+	return &obfRand{rand, testObf, newProxyDispatcher(rand, nameFunc), obfuscators, cheapLiteralObfuscators}
 }

--- a/internal/literals/seed.go
+++ b/internal/literals/seed.go
@@ -13,8 +13,12 @@ import (
 
 type seed struct{}
 
-// check that the obfuscator interface is implemented
-var _ obfuscator = seed{}
+// check that the Obfuscator interface is implemented
+var _ Obfuscator = seed{}
+
+func (seed) isCheap() bool {
+	return false;
+}
 
 func (seed) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*externalKey) *ast.BlockStmt {
 	seed := byte(obfRand.Uint32())

--- a/internal/literals/shuffle.go
+++ b/internal/literals/shuffle.go
@@ -13,9 +13,11 @@ import (
 
 type shuffle struct{}
 
-// check that the obfuscator interface is implemented
-var _ obfuscator = shuffle{}
-
+// check that the Obfuscator interface is implemented
+var _ Obfuscator = shuffle{}
+func (shuffle) isCheap() bool {
+	return false;
+}
 func (shuffle) obfuscate(rand *mathrand.Rand, data []byte, extKeys []*externalKey) *ast.BlockStmt {
 	key := make([]byte, len(data))
 	rand.Read(key)

--- a/internal/literals/simple.go
+++ b/internal/literals/simple.go
@@ -13,8 +13,12 @@ import (
 
 type simple struct{}
 
-// check that the obfuscator interface is implemented
-var _ obfuscator = simple{}
+// check that the Obfuscator interface is implemented
+var _ Obfuscator = simple{}
+
+func (simple) isCheap() bool {
+	return true;
+}
 
 func (simple) obfuscate(rand *mathrand.Rand, data []byte, extKeys []*externalKey) *ast.BlockStmt {
 	key := make([]byte, len(data))

--- a/internal/literals/split.go
+++ b/internal/literals/split.go
@@ -20,8 +20,12 @@ const (
 // then encrypts them using xor.
 type split struct{}
 
-// check that the obfuscator interface is implemented
-var _ obfuscator = split{}
+// check that the Obfuscator interface is implemented
+var _ Obfuscator = split{}
+
+func (split) isCheap() bool {
+	return false;
+}
 
 func splitIntoRandomChunks(obfRand *mathrand.Rand, data []byte) [][]byte {
 	if len(data) == 1 {

--- a/internal/literals/swap.go
+++ b/internal/literals/swap.go
@@ -14,8 +14,12 @@ import (
 
 type swap struct{}
 
-// check that the obfuscator interface is implemented
-var _ obfuscator = swap{}
+// check that the Obfuscator interface is implemented
+var _ Obfuscator = swap{}
+
+func (swap) isCheap() bool {
+	return true;
+}
 
 func getIndexType(dataLen int64) string {
 	switch {

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"io/fs"
 	"iter"
 	"log"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,11 +27,13 @@ import (
 	"runtime"
 	"runtime/debug"
 	"runtime/pprof"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
 	"mvdan.cc/garble/internal/linker"
+	"mvdan.cc/garble/internal/literals"
 )
 
 const actionGraphFileName = "action-graph.json"
@@ -103,7 +106,7 @@ var booleanFlags = map[string]bool{
 }
 
 var flagSet = flag.NewFlagSet("garble", flag.ExitOnError)
-var rxGarbleFlag = regexp.MustCompile(`-(?:literals|tiny|debug|debugdir|seed)(?:$|=)`)
+var rxGarbleFlag = regexp.MustCompile(`-(?:literals|tiny|debug|debugdir|seed|literalObfuscators)(?:$|=)`)
 
 var (
 	flagLiterals bool
@@ -111,6 +114,7 @@ var (
 	flagDebug    bool
 	flagDebugDir string
 	flagSeed     seedFlag
+	flagLiteralObfuscators string
 	// TODO(pagran): in the future, when control flow obfuscation will be stable migrate to flag
 	flagControlFlow = os.Getenv("GARBLE_EXPERIMENTAL_CONTROLFLOW") == "1"
 
@@ -123,6 +127,7 @@ var (
 func init() {
 	flagSet.Usage = usage
 	flagSet.BoolVar(&flagLiterals, "literals", false, "Obfuscate literals such as strings")
+	flagSet.StringVar(&flagLiteralObfuscators, "literalObfuscators", "", "Comma-separated list of literal obfuscators to use, e.g. \"seed,shuffle,simple,split,swap\" (default uses all).")
 	flagSet.BoolVar(&flagTiny, "tiny", false, "Optimize for binary size, losing some ability to reverse the process")
 	flagSet.BoolVar(&flagDebug, "debug", false, "Print debug logs to stderr")
 	flagSet.StringVar(&flagDebugDir, "debugdir", "", "Write source and obfuscated trees to a directory, e.g. -debugdir=out")
@@ -280,6 +285,32 @@ func mainErr(args []string) error {
 				return alterToolVersion(tool, args)
 			}
 			var tf transformer
+
+			if flagLiterals {
+				var selectedLiteralObfuscatorsMap = literals.Obfuscators
+				if flagLiteralObfuscators != "" {
+					selectedLiteralObfuscatorsMap = make(map[string]literals.Obfuscator)
+					for _, obfuscatorName := range strings.Split(flagLiteralObfuscators, ",") {
+						obfuscator, contains := literals.Obfuscators[obfuscatorName]
+						if !contains {
+							return fmt.Errorf("unknown literal obfuscator: %s", obfuscatorName)
+						}
+						selectedLiteralObfuscatorsMap[obfuscatorName] = obfuscator
+					}
+				}
+				// To ensure a reproducible build, we need to order the obfuscators deterministically.
+				// We sort them by name
+				var selectedLiteralObfuscators []literals.Obfuscator;
+				for _, obfuscatorName := range slices.Sorted(maps.Keys(selectedLiteralObfuscatorsMap)) {
+					selectedLiteralObfuscators = append(selectedLiteralObfuscators, selectedLiteralObfuscatorsMap[obfuscatorName])
+				}
+				tf.literalObfuscators = selectedLiteralObfuscators
+			} else {
+				if flagLiteralObfuscators != "" {
+					return fmt.Errorf("specified literalObfuscators, but not obfuscating literals")
+				}
+			}
+
 			toolexecImportPath := os.Getenv("TOOLEXEC_IMPORTPATH")
 			tf.curPkg = sharedCache.ListedPackages[toolexecImportPath]
 			if tf.curPkg == nil {
@@ -431,6 +462,10 @@ This command wraps "go %s". Below is its help:
 		if err := os.WriteFile(sentinel, nil, 0o666); err != nil {
 			return nil, fmt.Errorf("could not create debugdir sentinel: %v", err)
 		}
+	}
+
+	if !flagLiterals && flagLiteralObfuscators != "" {
+		return nil, fmt.Errorf("specified literalObfuscators, but not obfuscating literals")
 	}
 
 	goArgs := append([]string{command}, garbleBuildFlags...)

--- a/transformer.go
+++ b/transformer.go
@@ -268,6 +268,10 @@ type transformer struct {
 	// if it is used for any other purpose, we may lose determinism.
 	obfRand *mathrand.Rand
 
+	// literalObfuscators provides the Obfuscators to use when obfuscating literals in a Go syntax
+	// file.
+	literalObfuscators []literals.Obfuscator
+
 	// origImporter is a go/types importer which uses the original versions
 	// of packages, without any obfuscation. This is helpful to make
 	// decisions on how to obfuscate our input code.
@@ -1216,7 +1220,7 @@ func (tf *transformer) transformGoFile(file *ast.File) *ast.File {
 	// because obfuscated literals sometimes escape to heap,
 	// and that's not allowed in the runtime itself.
 	if flagLiterals && tf.curPkg.ToObfuscate {
-		file = literals.Obfuscate(tf.obfRand, file, tf.info, tf.linkerVariableStrings, randomName)
+		file = literals.Obfuscate(tf.obfRand, file, tf.info, tf.literalObfuscators, tf.linkerVariableStrings, randomName)
 
 		// some imported constants might not be needed anymore, remove unnecessary imports
 		tf.useAllImports(file)


### PR DESCRIPTION
This PR adds a command-line option for selecting which literal obfuscators to use when literal obfuscation is enabled (addressing #1049).
When this command-line option is not specified, the existing behavior is unchanged.
The selected obfuscators are ordered deterministically before use, so builds remain reproducible.

The feature is used by passing a comma-separated list of obfuscator names:
```sh
garble -literals -literalObfuscators=seed,shuffle,simple,split,swap ...
```

Behavior overview:
| Command | Behavior |
| - | - |
| `garble -literals ...` | Garble uses all literal obfuscators | 
| `garble -literals -literalObfuscators=seed,shuffle ...` | Garble uses the `seed` and `shuffle` obfuscators | 
| `garble -literalObfuscators=seed,shuffle ...` | Error, obfuscating literals not enabled | 
