### PR TITLE
internal/literals: preserve constant string expression semantics

### DIFF
--- a/internal/literals/literals.go
+++ b/internal/literals/literals.go
@@ -41,6 +41,7 @@ type NameProviderFunc func(rand *mathrand.Rand, baseName string) string
 // Obfuscate replaces literals with obfuscated anonymous functions.
 func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkStrings map[*types.Var]string, nameFunc NameProviderFunc) *ast.File {
 	or := newObfRand(rand, file, nameFunc)
+	parents := nodeParents(file)
 	pre := func(cursor *astutil.Cursor) bool {
 		switch node := cursor.Node().(type) {
 		case *ast.FuncDecl:
@@ -83,14 +84,8 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 			return true
 		}
 
-		if typeAndValue.Type == types.Typ[types.String] && typeAndValue.Value != nil {
-			value := constant.StringVal(typeAndValue.Value)
-			if len(value) < MinSize || len(value) > MaxSize {
-				return true
-			}
-
+		if value, ok := obfuscatableString(node, info, parents); ok {
 			cursor.Replace(withPos(obfuscateString(or, value), node.Pos()))
-
 			return true
 		}
 
@@ -102,6 +97,9 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 			// See issue #520.
 
 			if node.Op != token.AND {
+				return true
+			}
+			if hasConstantValueAncestor(node, info, parents) {
 				return true
 			}
 
@@ -120,6 +118,13 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 			// replacing the node we're currently visiting, and the pointer variant
 			// requires us to move the ampersand operator.
 
+			if hasConstantValueAncestor(node, info, parents) {
+				// Constant len/cap/unsafe.Sizeof expressions do not evaluate an
+				// array operand. A decoder would be needless and can make an
+				// array length or keyed index stop being a constant.
+				return true
+			}
+
 			parent, ok := cursor.Parent().(*ast.UnaryExpr)
 			if ok && parent.Op == token.AND {
 				return true
@@ -137,6 +142,80 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 	newFile := astutil.Apply(file, pre, post).(*ast.File)
 	or.proxyDispatcher.AddToFile(newFile)
 	return newFile
+}
+
+// nodeParents records the original syntax ancestry before rewrites begin. It
+// lets string selection account for constant expressions above the immediate
+// astutil cursor parent without depending on already-replaced child nodes.
+func nodeParents(root ast.Node) map[ast.Node]ast.Node {
+	parents := make(map[ast.Node]ast.Node)
+	var stack []ast.Node
+	ast.Inspect(root, func(node ast.Node) bool {
+		if node == nil {
+			stack = stack[:len(stack)-1]
+			return false
+		}
+		if len(stack) > 0 {
+			parents[node] = stack[len(stack)-1]
+		}
+		stack = append(stack, node)
+		return true
+	})
+	return parents
+}
+
+// obfuscatableString selects only maximal materialized string constants.
+//
+// A larger eligible string expression will be rewritten when its post-order
+// turn arrives, so generating decoders for its children would only leave dead
+// generated expressions and proxy entries. Conversely, a surrounding constant
+// expression with a non-string result (for example len(s), a comparison, or
+// unsafe.Sizeof) is folded by the compiler. Rewriting a string below it is both
+// unnecessary and can make constant-required uses such as array lengths fail.
+func obfuscatableString(node ast.Expr, info *types.Info, parents map[ast.Node]ast.Node) (string, bool) {
+	typeAndValue := info.Types[node]
+	if typeAndValue.Type != types.Typ[types.String] || typeAndValue.Value == nil {
+		return "", false
+	}
+	value := constant.StringVal(typeAndValue.Value)
+	if len(value) < MinSize || len(value) > MaxSize {
+		return "", false
+	}
+
+	for parent := parents[node]; parent != nil; parent = parents[parent] {
+		expr, ok := parent.(ast.Expr)
+		if !ok {
+			continue
+		}
+		parentValue := info.Types[expr]
+		if parentValue.Value == nil || parentValue.Type == nil {
+			continue
+		}
+		if !isStringLike(parentValue.Type) {
+			return "", false
+		}
+		if parentValue.Type == types.Typ[types.String] {
+			parentString := constant.StringVal(parentValue.Value)
+			if len(parentString) >= MinSize && len(parentString) <= MaxSize {
+				return "", false
+			}
+		}
+	}
+	return value, true
+}
+
+func isStringLike(typ types.Type) bool {
+	basic, ok := typ.Underlying().(*types.Basic)
+	return ok && basic.Info()&types.IsString != 0
+}
+
+func hasConstantValueAncestor(node ast.Node, info *types.Info, parents map[ast.Node]ast.Node) bool {
+	for parent := parents[node]; parent != nil; parent = parents[parent] {
+		if expr, ok := parent.(ast.Expr); ok && info.Types[expr].Value != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // handleCompositeLiteral checks if the input node is []byte or [...]byte and

--- a/internal/literals/literals.go
+++ b/internal/literals/literals.go
@@ -41,7 +41,9 @@ type NameProviderFunc func(rand *mathrand.Rand, baseName string) string
 // Obfuscate replaces literals with obfuscated anonymous functions.
 func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkStrings map[*types.Var]string, nameFunc NameProviderFunc) *ast.File {
 	or := newObfRand(rand, file, nameFunc)
-	parents := nodeParents(file)
+	// Ancestors of the node currently being visited by astutil.Apply.
+	// Built from the cursor walk so parent checks do not need a separate map.
+	var ancestors []ast.Node
 	pre := func(cursor *astutil.Cursor) bool {
 		switch node := cursor.Node().(type) {
 		case *ast.FuncDecl:
@@ -70,10 +72,15 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 				}
 			}
 		}
+		ancestors = append(ancestors, cursor.Node())
 		return true
 	}
 
 	post := func(cursor *astutil.Cursor) bool {
+		defer func() {
+			ancestors = ancestors[:len(ancestors)-1]
+		}()
+
 		node, ok := cursor.Node().(ast.Expr)
 		if !ok {
 			return true
@@ -84,7 +91,7 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 			return true
 		}
 
-		if value, ok := obfuscatableString(node, info, parents); ok {
+		if value, ok := obfuscatableString(cursor, info, ancestors); ok {
 			cursor.Replace(withPos(obfuscateString(or, value), node.Pos()))
 			return true
 		}
@@ -99,7 +106,7 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 			if node.Op != token.AND {
 				return true
 			}
-			if hasConstantValueAncestor(node, info, parents) {
+			if hasConstantValueAncestor(info, ancestors) {
 				return true
 			}
 
@@ -118,7 +125,7 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 			// replacing the node we're currently visiting, and the pointer variant
 			// requires us to move the ampersand operator.
 
-			if hasConstantValueAncestor(node, info, parents) {
+			if hasConstantValueAncestor(info, ancestors) {
 				// Constant len/cap/unsafe.Sizeof expressions do not evaluate an
 				// array operand. A decoder would be needless and can make an
 				// array length or keyed index stop being a constant.
@@ -144,35 +151,17 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 	return newFile
 }
 
-// nodeParents records the original syntax ancestry before rewrites begin. It
-// lets string selection account for constant expressions above the immediate
-// astutil cursor parent without depending on already-replaced child nodes.
-func nodeParents(root ast.Node) map[ast.Node]ast.Node {
-	parents := make(map[ast.Node]ast.Node)
-	var stack []ast.Node
-	ast.Inspect(root, func(node ast.Node) bool {
-		if node == nil {
-			stack = stack[:len(stack)-1]
-			return false
-		}
-		if len(stack) > 0 {
-			parents[node] = stack[len(stack)-1]
-		}
-		stack = append(stack, node)
-		return true
-	})
-	return parents
-}
-
 // obfuscatableString selects only maximal materialized string constants.
 //
-// A larger eligible string expression will be rewritten when its post-order
-// turn arrives, so generating decoders for its children would only leave dead
-// generated expressions and proxy entries. Conversely, a surrounding constant
-// expression with a non-string result (for example len(s), a comparison, or
-// unsafe.Sizeof) is folded by the compiler. Rewriting a string below it is both
-// unnecessary and can make constant-required uses such as array lengths fail.
-func obfuscatableString(node ast.Expr, info *types.Info, parents map[ast.Node]ast.Node) (string, bool) {
+// Parent expressions are walked from the astutil.Apply cursor ancestry.
+// Exit conditions:
+//   - a constant non-string parent (len, comparison, sizeof, …): do not rewrite
+//   - an eligible parent string: rewrite that parent instead of this child
+func obfuscatableString(cursor *astutil.Cursor, info *types.Info, ancestors []ast.Node) (string, bool) {
+	node, ok := cursor.Node().(ast.Expr)
+	if !ok {
+		return "", false
+	}
 	typeAndValue := info.Types[node]
 	if typeAndValue.Type != types.Typ[types.String] || typeAndValue.Value == nil {
 		return "", false
@@ -182,10 +171,12 @@ func obfuscatableString(node ast.Expr, info *types.Info, parents map[ast.Node]as
 		return "", false
 	}
 
-	for parent := parents[node]; parent != nil; parent = parents[parent] {
-		expr, ok := parent.(ast.Expr)
+	// ancestors[len-1] is the cursor node; parents are below it toward the root.
+	for i := len(ancestors) - 2; i >= 0; i-- {
+		expr, ok := ancestors[i].(ast.Expr)
 		if !ok {
-			continue
+			// Left the expression tree (statement, decl, or file).
+			break
 		}
 		parentValue := info.Types[expr]
 		if parentValue.Value == nil || parentValue.Type == nil {
@@ -209,9 +200,16 @@ func isStringLike(typ types.Type) bool {
 	return ok && basic.Info()&types.IsString != 0
 }
 
-func hasConstantValueAncestor(node ast.Node, info *types.Info, parents map[ast.Node]ast.Node) bool {
-	for parent := parents[node]; parent != nil; parent = parents[parent] {
-		if expr, ok := parent.(ast.Expr); ok && info.Types[expr].Value != nil {
+// hasConstantValueAncestor reports whether any expression parent in the
+// astutil.Apply ancestry is a folded constant. Stops at the first
+// non-expression ancestor.
+func hasConstantValueAncestor(info *types.Info, ancestors []ast.Node) bool {
+	for i := len(ancestors) - 2; i >= 0; i-- {
+		expr, ok := ancestors[i].(ast.Expr)
+		if !ok {
+			break
+		}
+		if info.Types[expr].Value != nil {
 			return true
 		}
 	}

--- a/testdata/script/literals.txtar
+++ b/testdata/script/literals.txtar
@@ -3,7 +3,7 @@ exec ./main$exe
 cmp stderr main.stderr
 
 binsubstr main$exe 'skip typed const' 'skip typed var' 'skip typed var assign' 'stringTypeField strType' 'stringType lambda func return' 'testMap2 key' 'testMap3 key' 'testMap1 value' 'testMap3 value' 'testMap1 new value' 'testMap3 new value' 'stringType func param' 'stringType return' 'skip untyped const' 'sz<min'
-! binsubstr main$exe 'garbleDecrypt' 'Lorem Ipsum' 'dolor sit amet' 'first assign' 'second assign' 'First Line' 'Second Line' 'secret map value' 'obfuscated with shadowed builtins' '1: literal in' 'an secret array' '2: literal in' 'a secret slice' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 'testMap1 key' 'Obfuscate this block' 'also obfuscate this'
+! binsubstr main$exe 'garbleDecrypt' 'Lorem Ipsum' 'dolor sit amet' 'first assign' 'second assign' 'First Line' 'Second Line' 'secret map value' 'obfuscated with shadowed builtins' '1: literal in' 'an secret array' '2: literal in' 'a secret slice' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 'testMap1 key' 'Obfuscate this block' 'also obfuscate this' 'constant-context-secret' 'max-concat-secret'
 
 [short] stop # checking that the build is reproducible is slow
 
@@ -17,7 +17,7 @@ bincmp main$exe main_old$exe
 go build
 exec ./main$exe
 cmp stderr main.stderr
-binsubstr main$exe 'Lorem Ipsum' 'dolor sit amet' 'second assign' 'First Line' 'Second Line' 'secret map value' 'obfuscated with shadowed builtins' '1: literal in' 'an secret array' '2: literal in' 'a secret slice' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 'testMap1 key' 'Obfuscate this block' 'also obfuscate this'
+binsubstr main$exe 'Lorem Ipsum' 'dolor sit amet' 'second assign' 'First Line' 'Second Line' 'secret map value' 'obfuscated with shadowed builtins' '1: literal in' 'an secret array' '2: literal in' 'a secret slice' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 'testMap1 key' 'Obfuscate this block' 'also obfuscate this' 'max-concat-secret'
 
 # Generate and write random literals into a separate file.
 # Some of them will be huge; assuming that we don't try to obfuscate them, the
@@ -89,6 +89,25 @@ var array [arrayLen]byte
 
 type typeAlias [arrayLen]byte
 
+const constantContextString string = "constant-context-secret"
+
+const maxConcatPadding128 = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+const maxConcatPadding256 = maxConcatPadding128 + maxConcatPadding128
+const maxConcatPadding512 = maxConcatPadding256 + maxConcatPadding256
+const maxConcatPadding1024 = maxConcatPadding512 + maxConcatPadding512
+const maxConcatPadding2048 = maxConcatPadding1024 + maxConcatPadding1024
+
+type constantContextAlias string
+type constantContextArray [len(constantContextString)]byte
+
+var constantContextValue [len(constantContextString)]byte
+var constantContextNamed [len(constantContextAlias(constantContextString))]byte
+var constantContextKeyed = [len(constantContextString)]byte{len(constantContextString) - 1: 1}
+
+type constantArrayLiteralLen [len([8]byte{1, 2, 3, 4, 5, 6, 7, 8})]byte
+type constantArrayLiteralCap [cap([8]byte{1, 2, 3, 4, 5, 6, 7, 8})]byte
+type constantArrayPointerLen [len(&[8]byte{1, 2, 3, 4, 5, 6, 7, 8})]byte
+
 func main() {
 	empty := ""
 	tooSmall := "sz<min"
@@ -99,9 +118,11 @@ func main() {
 	reassign = "second assign"
 
 	add := "totally long" + "unnecessarily added string"
+	maxConcat := string("max-concat-secret") + maxConcatPadding2048
 
 	println(cnst, boolean)
 	println(multiline, add)
+	println(maxConcat[:17])
 	println(localVar)
 	println(reassign)
 	println(empty)
@@ -125,6 +146,8 @@ func main() {
 	println("another literal")
 	println(mixedBlock, iotaBlock)
 	println(i, foo, bar)
+	println(len(constantContextArray{}), len(constantContextValue), len(constantContextNamed), len(constantContextKeyed))
+	println(len(constantArrayLiteralLen{}), len(constantArrayLiteralCap{}), len(constantArrayPointerLen{}))
 	typedTest()
 	constantTest()
 	byteTest()
@@ -459,6 +482,7 @@ func str9() { println("foo bar bar") }
 Lorem Ipsum true
 First Line
 Second Line totally longunnecessarily added string
+max-concat-secret
 dolor sit amet
 second assign
 
@@ -469,6 +493,8 @@ secret new value
 another literal
 Obfuscate this block also obfuscate this
 1 0 1
+23 23 23 23
+8 8 8
 skip untyped const
 skip typed const skip typed var skip typed var assign
 stringTypeField String stringTypeField strType

--- a/testdata/script/literals.txtar
+++ b/testdata/script/literals.txtar
@@ -3,6 +3,8 @@ exec ./main$exe
 cmp stderr main.stderr
 
 binsubstr main$exe 'skip typed const' 'skip typed var' 'skip typed var assign' 'stringTypeField strType' 'stringType lambda func return' 'testMap2 key' 'testMap3 key' 'testMap1 value' 'testMap3 value' 'testMap1 new value' 'testMap3 new value' 'stringType func param' 'stringType return' 'skip untyped const' 'sz<min'
+# constant-context-secret: only referenced from folded constant exprs (should not remain as a runtime literal payload).
+# max-concat-secret: eligible child under an oversize concat (must still be obfuscated).
 ! binsubstr main$exe 'garbleDecrypt' 'Lorem Ipsum' 'dolor sit amet' 'first assign' 'second assign' 'First Line' 'Second Line' 'secret map value' 'obfuscated with shadowed builtins' '1: literal in' 'an secret array' '2: literal in' 'a secret slice' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 'testMap1 key' 'Obfuscate this block' 'also obfuscate this' 'constant-context-secret' 'max-concat-secret'
 
 [short] stop # checking that the build is reproducible is slow
@@ -89,8 +91,14 @@ var array [arrayLen]byte
 
 type typeAlias [arrayLen]byte
 
+// Broke before: rewriting "constant-context-secret" under len()/conversions
+// made array lengths and keyed indexes stop being constants (build failure),
+// and left dead decoders for strings that only feed folded constant exprs.
 const constantContextString string = "constant-context-secret"
 
+// Padding so that string("max-concat-secret") + padding exceeds MaxSize.
+// Broke before: a too-large parent concat suppressed the eligible child, so
+// "max-concat-secret" stayed plaintext in the -literals binary.
 const maxConcatPadding128 = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
 const maxConcatPadding256 = maxConcatPadding128 + maxConcatPadding128
 const maxConcatPadding512 = maxConcatPadding256 + maxConcatPadding256
@@ -98,12 +106,17 @@ const maxConcatPadding1024 = maxConcatPadding512 + maxConcatPadding512
 const maxConcatPadding2048 = maxConcatPadding1024 + maxConcatPadding1024
 
 type constantContextAlias string
+// Broke before: len(constant string) as an array length stopped compiling
+// when the string below was rewritten to a runtime decoder call.
 type constantContextArray [len(constantContextString)]byte
 
 var constantContextValue [len(constantContextString)]byte
 var constantContextNamed [len(constantContextAlias(constantContextString))]byte
+// Broke before: keyed index len(s)-1 must stay a constant; rewriting s broke it.
 var constantContextKeyed = [len(constantContextString)]byte{len(constantContextString) - 1: 1}
 
+// Broke before: len/cap/& of a byte array literal under a constant array length
+// was rewritten to a decoder, so the length was no longer constant.
 type constantArrayLiteralLen [len([8]byte{1, 2, 3, 4, 5, 6, 7, 8})]byte
 type constantArrayLiteralCap [cap([8]byte{1, 2, 3, 4, 5, 6, 7, 8})]byte
 type constantArrayPointerLen [len(&[8]byte{1, 2, 3, 4, 5, 6, 7, 8})]byte
@@ -118,6 +131,8 @@ func main() {
 	reassign = "second assign"
 
 	add := "totally long" + "unnecessarily added string"
+	// Child "max-concat-secret" is eligible; parent concat is above MaxSize so
+	// the child must still be obfuscated (see binsubstr checks above).
 	maxConcat := string("max-concat-secret") + maxConcatPadding2048
 
 	println(cnst, boolean)
@@ -146,6 +161,8 @@ func main() {
 	println("another literal")
 	println(mixedBlock, iotaBlock)
 	println(i, foo, bar)
+	// Exercise the constant-context types/vars so a regression fails at build
+	// or at runtime rather than being dead-code eliminated.
 	println(len(constantContextArray{}), len(constantContextValue), len(constantContextNamed), len(constantContextKeyed))
 	println(len(constantArrayLiteralLen{}), len(constantArrayLiteralCap{}), len(constantArrayPointerLen{}))
 	typedTest()


### PR DESCRIPTION
Rewriting a string below a folded constant expression can make array lengths,
keyed indexes, and similar constant-required uses stop compiling. Rewriting
children of a larger string constant also generates dead decoders and proxy
entries. A string parent larger than Garble's maximum must not suppress an
eligible child, because that would expose the child plaintext.

Record original AST ancestry, skip strings under non-string constant results,
and select only the largest eligible string expression. A parent suppresses an
eligible child only when that parent itself is within the configured literal
size range.