### PR TITLE
internal/literals: handle parenthesized addressed byte literals

### DIFF
--- a/internal/literals/literals.go
+++ b/internal/literals/literals.go
@@ -41,6 +41,7 @@ type NameProviderFunc func(rand *mathrand.Rand, baseName string) string
 // Obfuscate replaces literals with obfuscated anonymous functions.
 func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkStrings map[*types.Var]string, nameFunc NameProviderFunc) *ast.File {
 	or := newObfRand(rand, file, nameFunc)
+	addressed := addressedCompositeLiterals(file, info)
 	pre := func(cursor *astutil.Cursor) bool {
 		switch node := cursor.Node().(type) {
 		case *ast.FuncDecl:
@@ -67,6 +68,24 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 					// TODO: support obfuscating those injected strings, too.
 					return false
 				}
+			}
+		case *ast.UnaryExpr:
+			addressedLiteral, ok := addressed[node]
+			if !ok {
+				return true
+			}
+			if addressedLiteral.constantContext {
+				// A constant len/cap expression does not evaluate its array
+				// operand. Leave the entire address expression unchanged.
+				return false
+			}
+			newnode := handleCompositeLiteral(or, true, addressedLiteral.literal, info)
+			if newnode != nil {
+				// Replace the entire address expression before visiting its
+				// child. In particular, a parenthesized composite must never
+				// first become &(decoder()), since a call is not addressable.
+				cursor.Replace(newnode)
+				return false
 			}
 		}
 		return true
@@ -137,6 +156,54 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 	newFile := astutil.Apply(file, pre, post).(*ast.File)
 	or.proxyDispatcher.AddToFile(newFile)
 	return newFile
+}
+
+type addressedCompositeLiteral struct {
+	literal         *ast.CompositeLit
+	constantContext bool
+}
+
+// addressedCompositeLiterals finds address expressions whose operand is a
+// composite literal, allowing any number of parentheses around the literal.
+// It records constant ancestors so the rewrite does not turn a constant
+// len/cap expression into a runtime call.
+func addressedCompositeLiterals(root ast.Node, info *types.Info) map[*ast.UnaryExpr]addressedCompositeLiteral {
+	result := make(map[*ast.UnaryExpr]addressedCompositeLiteral)
+	var stack []ast.Node
+	ast.Inspect(root, func(node ast.Node) bool {
+		if node == nil {
+			stack = stack[:len(stack)-1]
+			return false
+		}
+		if unary, ok := node.(*ast.UnaryExpr); ok && unary.Op == token.AND {
+			if literal := unwrapCompositeLiteral(unary.X); literal != nil {
+				constantContext := false
+				for _, ancestor := range stack {
+					if expr, ok := ancestor.(ast.Expr); ok && info.Types[expr].Value != nil {
+						constantContext = true
+						break
+					}
+				}
+				result[unary] = addressedCompositeLiteral{literal: literal, constantContext: constantContext}
+			}
+		}
+		stack = append(stack, node)
+		return true
+	})
+	return result
+}
+
+func unwrapCompositeLiteral(expr ast.Expr) *ast.CompositeLit {
+	for {
+		switch node := expr.(type) {
+		case *ast.CompositeLit:
+			return node
+		case *ast.ParenExpr:
+			expr = node.X
+		default:
+			return nil
+		}
+	}
 }
 
 // handleCompositeLiteral checks if the input node is []byte or [...]byte and

--- a/internal/literals/literals.go
+++ b/internal/literals/literals.go
@@ -70,6 +70,21 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 			}
 
 		case ast.Expr:
+			// Rewrite &[]byte{...} as a whole on the way down. Rewriting the
+			// composite literal on its own would leave behind &(decoder()),
+			// which is not addressable, and parentheses in the input would
+			// hide the literal from a check on the way up.
+			//
+			// See issue #520.
+			if unary, ok := node.(*ast.UnaryExpr); ok && unary.Op == token.AND {
+				if lit, ok := ast.Unparen(unary.X).(*ast.CompositeLit); ok {
+					if newNode := handleCompositeLiteral(or, true, lit, info); newNode != nil {
+						cursor.Replace(newNode)
+						return false
+					}
+				}
+			}
+
 			// The compiler folds constant expressions, so only the outermost
 			// one exists at run time. Rewrite that one and stop descending,
 			// rather than also rewriting its operands into dead decoders.
@@ -99,53 +114,14 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 	}
 
 	post := func(cursor *astutil.Cursor) bool {
-		node, ok := cursor.Node().(ast.Expr)
-		if !ok {
-			return true
-		}
-
-		typeAndValue := info.Types[node]
-		if !typeAndValue.IsValue() {
-			return true
-		}
-
-		switch node := node.(type) {
-		case *ast.UnaryExpr:
-			// Account for the possibility of address operators like
-			// &[]byte used inline with function arguments.
-			//
-			// See issue #520.
-
-			if node.Op != token.AND {
-				return true
-			}
-
-			if child, ok := node.X.(*ast.CompositeLit); ok {
-				newnode := handleCompositeLiteral(or, true, child, info)
-				if newnode != nil {
-					cursor.Replace(newnode)
-				}
-			}
-
-		case *ast.CompositeLit:
-			// We replaced the &[]byte{...} case above. Here we account for the
-			// standard []byte{...} or [4]byte{...} value form.
-			//
-			// We need two separate calls to cursor.Replace, as it only supports
-			// replacing the node we're currently visiting, and the pointer variant
-			// requires us to move the ampersand operator.
-
-			parent, ok := cursor.Parent().(*ast.UnaryExpr)
-			if ok && parent.Op == token.AND {
-				return true
-			}
-
-			newnode := handleCompositeLiteral(or, false, node, info)
-			if newnode != nil {
-				cursor.Replace(newnode)
+		// Here we handle the plain []byte{...} or [4]byte{...} value form.
+		// The pointer form was already replaced on the way down; a literal
+		// which we declined there is declined here just the same.
+		if lit, ok := cursor.Node().(*ast.CompositeLit); ok {
+			if newNode := handleCompositeLiteral(or, false, lit, info); newNode != nil {
+				cursor.Replace(newNode)
 			}
 		}
-
 		return true
 	}
 

--- a/testdata/script/literals.txtar
+++ b/testdata/script/literals.txtar
@@ -3,7 +3,7 @@ exec ./main$exe
 cmp stderr main.stderr
 
 binsubstr main$exe 'skip typed const' 'skip typed var' 'skip typed var assign' 'stringTypeField strType' 'stringType lambda func return' 'testMap2 key' 'testMap3 key' 'testMap1 value' 'testMap3 value' 'testMap1 new value' 'testMap3 new value' 'stringType func param' 'stringType return' 'skip untyped const' 'sz<min'
-! binsubstr main$exe 'garbleDecrypt' 'Lorem Ipsum' 'dolor sit amet' 'first assign' 'second assign' 'First Line' 'Second Line' 'secret map value' 'obfuscated with shadowed builtins' '1: literal in' 'an secret array' '2: literal in' 'a secret slice' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 'testMap1 key' 'Obfuscate this block' 'also obfuscate this'
+! binsubstr main$exe 'garbleDecrypt' 'Lorem Ipsum' 'dolor sit amet' 'first assign' 'second assign' 'First Line' 'Second Line' 'secret map value' 'obfuscated with shadowed builtins' '1: literal in' 'an secret array' '2: literal in' 'a secret slice' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 'testMap1 key' 'Obfuscate this block' 'also obfuscate this' 'parens!!'
 
 [short] stop # checking that the build is reproducible is slow
 
@@ -88,6 +88,8 @@ const arrayLen = 4
 var array [arrayLen]byte
 
 type typeAlias [arrayLen]byte
+
+type parenthesizedArrayPointerLen [len(&(([8]byte{1, 2, 3, 4, 5, 6, 7, 8})))]byte
 
 func main() {
 	empty := ""
@@ -278,6 +280,20 @@ func byteTest() {
 			print(elm, ",")
 		}
 	}(&[9]byte{99, 104, 117, 110, 103, 117, 115, 117, 115})
+	println()
+
+	// Parentheses used to make the literal rewriter leave an invalid
+	// &(decoder()) expression behind.
+	func(s *[]byte) {
+		print(string(*s))
+	}(&([]byte{112, 97, 114, 101, 110, 115, '!', '!'}))
+	println()
+
+	func(s *[9]byte) {
+		for _, elm := range s {
+			print(elm, ",")
+		}
+	}(&(([9]byte{112, 97, 114, 101, 110, 115, 101, 115, 33})))
 	println()
 }
 
@@ -487,6 +503,8 @@ big chungus
 chungus!!
 99,104,117,110,103,117,115,117,115,
 99,104,117,110,103,117,115,117,115,
+parens!!
+112,97,114,101,110,115,101,115,33,
 obfuscated with shadowed builtins (vars)
 obfuscated with shadowed builtins (types)
 const str from dot imported var

--- a/testdata/script/literals.txtar
+++ b/testdata/script/literals.txtar
@@ -3,7 +3,7 @@ exec ./main$exe
 cmp stderr main.stderr
 
 binsubstr main$exe 'skip typed const' 'skip typed var' 'skip typed var assign' 'stringTypeField strType' 'stringType lambda func return' 'testMap2 key' 'testMap3 key' 'testMap1 value' 'testMap3 value' 'testMap1 new value' 'testMap3 new value' 'stringType func param' 'stringType return' 'skip untyped const' 'sz<min'
-! binsubstr main$exe 'garbleDecrypt' 'Lorem Ipsum' 'dolor sit amet' 'first assign' 'second assign' 'First Line' 'Second Line' 'secret map value' 'obfuscated with shadowed builtins' '1: literal in' 'an secret array' '2: literal in' 'a secret slice' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 'testMap1 key' 'Obfuscate this block' 'also obfuscate this' 'oversize concat secret'
+! binsubstr main$exe 'garbleDecrypt' 'Lorem Ipsum' 'dolor sit amet' 'first assign' 'second assign' 'First Line' 'Second Line' 'secret map value' 'obfuscated with shadowed builtins' '1: literal in' 'an secret array' '2: literal in' 'a secret slice' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 'testMap1 key' 'Obfuscate this block' 'also obfuscate this' 'oversize concat secret' 'parens!!'
 
 [short] stop # checking that the build is reproducible is slow
 
@@ -88,6 +88,8 @@ const arrayLen = 4
 var array [arrayLen]byte
 
 type typeAlias [arrayLen]byte
+
+type namedByteSlice []byte
 
 // Strings which are only used inside constant expressions must be left alone;
 // rewriting them into decoder calls would stop the constants from compiling.
@@ -300,6 +302,19 @@ func byteTest() {
 		}
 	}(&[9]byte{99, 104, 117, 110, 103, 117, 115, 117, 115})
 	println()
+
+	// Parentheses used to leave the invalid &(decoder()) behind.
+	func(s *[]byte) {
+		print(string(*s))
+	}(&(([]byte{112, 97, 114, 101, 110, 115, '!', '!'})))
+	println()
+
+	// A composite literal which we leave alone must keep its parentheses,
+	// as dropping them would not parse inside an if statement.
+	var namedPtr *namedByteSlice
+	if namedPtr == &(namedByteSlice{1, 2, 3, 4, 5, 6, 7, 8}) {
+		println("unreachable")
+	}
 }
 
 func stringTypeFunc(s stringType) stringType {
@@ -510,6 +525,7 @@ big chungus
 chungus!!
 99,104,117,110,103,117,115,117,115,
 99,104,117,110,103,117,115,117,115,
+parens!!
 obfuscated with shadowed builtins (vars)
 obfuscated with shadowed builtins (types)
 const str from dot imported var


### PR DESCRIPTION
For forms such as `&([]byte{...})`, the post-order rewrite can transform the
child first and leave `&(decoder())`, which is not addressable and does not
compile. Extra parentheses expose the same bug for byte arrays.
