### PR TITLE
internal/literals: preserve decoded byte-slice capacity

### DIFF
--- a/internal/literals/fuzz_test.go
+++ b/internal/literals/fuzz_test.go
@@ -35,6 +35,8 @@ func main() {
 	println("--")
 	println(string(byt))
 	println(string(*bytPtr))
+	println(len(byt), cap(byt))
+	println(len(*bytPtr), cap(*bytPtr))
 }
 `[1:]
 
@@ -102,7 +104,7 @@ func FuzzObfuscate(f *testing.F) {
 		// Run the binary, expecting the output to match.
 		out, err := exec.Command(binPath).CombinedOutput()
 		qt.Assert(t, qt.IsNil(err))
-		want := fmt.Sprintf("%[1]s\nx%[1]sy\n--\n%[1]s\n%[1]s\n", in)
+		want := fmt.Sprintf("%[1]s\nx%[1]sy\n--\n%[1]s\n%[1]s\n%[2]d %[2]d\n%[2]d %[2]d\n", in, len(in))
 		qt.Assert(t, qt.Equals(string(out), want))
 	})
 }

--- a/internal/literals/fuzz_test.go
+++ b/internal/literals/fuzz_test.go
@@ -35,6 +35,9 @@ func main() {
 	println("--")
 	println(string(byt))
 	println(string(*bytPtr))
+	// The decoded slices must have the same cap as the original literals.
+	println(len(byt), cap(byt))
+	println(len(*bytPtr), cap(*bytPtr))
 }
 `[1:]
 
@@ -102,7 +105,7 @@ func FuzzObfuscate(f *testing.F) {
 		// Run the binary, expecting the output to match.
 		out, err := exec.Command(binPath).CombinedOutput()
 		qt.Assert(t, qt.IsNil(err))
-		want := fmt.Sprintf("%[1]s\nx%[1]sy\n--\n%[1]s\n%[1]s\n", in)
+		want := fmt.Sprintf("%[1]s\nx%[1]sy\n--\n%[1]s\n%[1]s\n%[2]d %[2]d\n%[2]d %[2]d\n", in, len(in))
 		qt.Assert(t, qt.Equals(string(out), want))
 	})
 }

--- a/internal/literals/generation_regression_test.go
+++ b/internal/literals/generation_regression_test.go
@@ -1,0 +1,67 @@
+package literals
+
+import (
+	"go/ast"
+	"go/token"
+	mathrand "math/rand"
+	"strconv"
+	"testing"
+)
+
+func TestByteSliceDecoderCapacityMatchesLiteral(t *testing.T) {
+	data := []byte{0, 1, 2, 3, 4, 5, 6, 7}
+	for _, tc := range []struct {
+		name string
+		obf  obfuscator
+	}{
+		{"seed", seed{}},
+		{"shuffle", shuffle{}},
+		{"split", split{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Inspect the decoder before its call-site wrapper is chosen. The
+			// capacity contract is independent of whether that wrapper is a
+			// closure or a lifted top-level function.
+			rnd := mathrand.New(mathrand.NewSource(1))
+			decoder := tc.obf.obfuscate(
+				rnd,
+				append([]byte(nil), data...),
+				randExtKeys(rnd),
+			)
+
+			var capacities []int
+			ast.Inspect(decoder, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok || len(call.Args) != 3 {
+					return true
+				}
+				fun, ok := call.Fun.(*ast.Ident)
+				if !ok || fun.Name != "make" || !isGeneratedByteSliceType(call.Args[0]) {
+					return true
+				}
+				literal, ok := call.Args[2].(*ast.BasicLit)
+				if !ok || literal.Kind != token.INT {
+					t.Fatalf("make capacity=%T, want integer literal", call.Args[2])
+				}
+				capacity, err := strconv.Atoi(literal.Value)
+				if err != nil {
+					t.Fatal(err)
+				}
+				capacities = append(capacities, capacity)
+				return true
+			})
+			if len(capacities) != 1 || capacities[0] != len(data) {
+				t.Fatalf("decoded capacities=%v, want [%d]", capacities, len(data))
+			}
+		})
+	}
+}
+
+func isGeneratedByteSliceType(expr ast.Expr) bool {
+	array, ok := expr.(*ast.ArrayType)
+	if !ok || array.Len != nil {
+		return false
+	}
+	element, ok := array.Elt.(*ast.Ident)
+	return ok && element.Name == "byte"
+}

--- a/internal/literals/obfuscators.go
+++ b/internal/literals/obfuscators.go
@@ -200,6 +200,14 @@ func (key *externalKey) ToExpr(b int) ast.Expr {
 	return x
 }
 
+// makeDataStmt returns "data := make([]byte, 0, size)" for decoders which build
+// up their result via append. The capacity is exact, so that the decoded slice
+// has the same cap as the literal it replaces.
+func makeDataStmt(size int) *ast.AssignStmt {
+	return ah.AssignDefineStmt(ast.NewIdent("data"),
+		ah.CallExprByName("make", ah.ByteSliceType(), ah.IntLit(0), ah.IntLit(size)))
+}
+
 // dataToByteSliceWithExtKeys scramble and turn a byte slice into an AST expression like:
 //
 //	func() []byte {

--- a/internal/literals/seed.go
+++ b/internal/literals/seed.go
@@ -40,14 +40,15 @@ func (seed) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*externalKe
 			Tok: token.DEFINE,
 			Rhs: []ast.Expr{ah.CallExprByName("byte", byteLitWithExtKey(obfRand, originalSeed, extKeys, highProb))},
 		},
-		&ast.DeclStmt{
-			Decl: &ast.GenDecl{
-				Tok: token.VAR,
-				Specs: []ast.Spec{&ast.ValueSpec{
-					Names: []*ast.Ident{ast.NewIdent("data")},
-					Type:  &ast.ArrayType{Elt: ast.NewIdent("byte")},
-				}},
-			},
+		&ast.AssignStmt{
+			Lhs: []ast.Expr{ast.NewIdent("data")},
+			Tok: token.DEFINE,
+			Rhs: []ast.Expr{ah.CallExpr(
+				ast.NewIdent("make"),
+				&ast.ArrayType{Elt: ast.NewIdent("byte")},
+				ah.IntLit(0),
+				ah.IntLit(len(data)),
+			)},
 		},
 		&ast.DeclStmt{
 			Decl: &ast.GenDecl{

--- a/internal/literals/seed.go
+++ b/internal/literals/seed.go
@@ -40,15 +40,7 @@ func (seed) obfuscate(obfRand *mathrand.Rand, data []byte, extKeys []*externalKe
 			Tok: token.DEFINE,
 			Rhs: []ast.Expr{ah.CallExprByName("byte", byteLitWithExtKey(obfRand, originalSeed, extKeys, highProb))},
 		},
-		&ast.DeclStmt{
-			Decl: &ast.GenDecl{
-				Tok: token.VAR,
-				Specs: []ast.Spec{&ast.ValueSpec{
-					Names: []*ast.Ident{ast.NewIdent("data")},
-					Type:  &ast.ArrayType{Elt: ast.NewIdent("byte")},
-				}},
-			},
-		},
+		makeDataStmt(len(data)),
 		&ast.DeclStmt{
 			Decl: &ast.GenDecl{
 				Tok: token.TYPE,

--- a/internal/literals/shuffle.go
+++ b/internal/literals/shuffle.go
@@ -79,7 +79,7 @@ func (shuffle) obfuscate(rand *mathrand.Rand, data []byte, extKeys []*externalKe
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("data")},
 			Tok: token.DEFINE,
-			Rhs: []ast.Expr{ah.CallExpr(ast.NewIdent("make"), &ast.ArrayType{Elt: ast.NewIdent("byte")}, ah.IntLit(0), ah.IntLit(len(data)+1))},
+			Rhs: []ast.Expr{ah.CallExpr(ast.NewIdent("make"), &ast.ArrayType{Elt: ast.NewIdent("byte")}, ah.IntLit(0), ah.IntLit(len(data)))},
 		},
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("data")},

--- a/internal/literals/shuffle.go
+++ b/internal/literals/shuffle.go
@@ -76,11 +76,7 @@ func (shuffle) obfuscate(rand *mathrand.Rand, data []byte, extKeys []*externalKe
 			Tok: token.DEFINE,
 			Rhs: []ast.Expr{dataToByteSliceWithExtKeys(rand, idxKey, extKeys)},
 		},
-		&ast.AssignStmt{
-			Lhs: []ast.Expr{ast.NewIdent("data")},
-			Tok: token.DEFINE,
-			Rhs: []ast.Expr{ah.CallExpr(ast.NewIdent("make"), &ast.ArrayType{Elt: ast.NewIdent("byte")}, ah.IntLit(0), ah.IntLit(len(data)+1))},
-		},
+		makeDataStmt(len(data)),
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("data")},
 			Tok: token.ASSIGN,

--- a/internal/literals/split.go
+++ b/internal/literals/split.go
@@ -158,7 +158,7 @@ func (split) obfuscate(rand *mathrand.Rand, data []byte, extKeys []*externalKey)
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("data")},
 			Tok: token.DEFINE,
-			Rhs: []ast.Expr{ah.CallExpr(ast.NewIdent("make"), &ast.ArrayType{Elt: ast.NewIdent("byte")}, ah.IntLit(0), ah.IntLit(len(data)+1))},
+			Rhs: []ast.Expr{ah.CallExpr(ast.NewIdent("make"), &ast.ArrayType{Elt: ast.NewIdent("byte")}, ah.IntLit(0), ah.IntLit(len(data)))},
 		},
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("i")},

--- a/internal/literals/split.go
+++ b/internal/literals/split.go
@@ -155,11 +155,7 @@ func (split) obfuscate(rand *mathrand.Rand, data []byte, extKeys []*externalKey)
 	}
 
 	return ah.BlockStmt(
-		&ast.AssignStmt{
-			Lhs: []ast.Expr{ast.NewIdent("data")},
-			Tok: token.DEFINE,
-			Rhs: []ast.Expr{ah.CallExpr(ast.NewIdent("make"), &ast.ArrayType{Elt: ast.NewIdent("byte")}, ah.IntLit(0), ah.IntLit(len(data)+1))},
-		},
+		makeDataStmt(len(data)),
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent("i")},
 			Tok: token.DEFINE,


### PR DESCRIPTION
The seed decoder starts with a nil slice, while shuffle and split reserve one
extra element. The decoded value has the right bytes but an observably
different `cap` from the source `[]byte{...}` literal.

Allocate each decoder result with length zero and capacity exactly equal to the
literal length. Decoding and literal secrecy are otherwise unchanged.