### PR TITLE
strip native linker identities alongside Go build IDs

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"debug/elf"
 	"flag"
 	"fmt"
 	"go/ast"
@@ -144,6 +145,7 @@ func TestScript(t *testing.T) {
 			"sleep":             sleep,
 			"binsubstr":         binsubstr,
 			"bincmp":            bincmp,
+			"elfsection":        elfsection,
 			"generate-literals": generateLiterals,
 			"setenvfile":        setenvfile,
 			"grepfiles":         grepfiles,
@@ -244,6 +246,24 @@ func bincmp(ts *testscript.TestScript, neg bool, args []string) {
 		sizeDiff := len(data2) - len(data1)
 		ts.Fatalf("%s and %s differ; size diff: %+d",
 			args[0], args[1], sizeDiff)
+	}
+}
+
+func elfsection(ts *testscript.TestScript, neg bool, args []string) {
+	if len(args) != 2 {
+		ts.Fatalf("usage: elfsection file section")
+	}
+	file, err := elf.Open(ts.MkAbs(args[0]))
+	if err != nil {
+		ts.Fatalf("opening ELF %s: %v", args[0], err)
+	}
+	defer file.Close()
+	found := file.Section(args[1]) != nil
+	if found == neg {
+		if neg {
+			ts.Fatalf("unexpected ELF section %s in %s", args[1], args[0])
+		}
+		ts.Fatalf("expected ELF section %s in %s", args[1], args[0])
 	}
 }
 
@@ -494,4 +514,31 @@ func TestFlagValue(t *testing.T) {
 			qt.Assert(t, qt.DeepEquals(got, test.want))
 		})
 	}
+}
+
+func TestStripLinkerIdentities(t *testing.T) {
+	t.Parallel()
+	flags := stripLinkerIdentities([]string{
+		"-buildid=first-go-identity",
+		"-B", "0x1122",
+		"-other=value",
+		"-buildid", "second-go-identity",
+		"-B=0x3344",
+	})
+	qt.Assert(t, qt.Equals(flagValue(flags, "-buildid"), ""))
+	qt.Assert(t, qt.Equals(flagValue(flags, "-B"), "none"))
+	qt.Assert(t, qt.DeepEquals(flags, []string{"-other=value", "-buildid=", "-B=none"}))
+}
+
+func TestStripLinuxExternalBuildIDOverride(t *testing.T) {
+	t.Parallel()
+	flags := stripLinuxExternalBuildIDOverride([]string{
+		"-extldflags=-Wl,--build-id=sha1 -Wl,--as-needed",
+		"-other=value",
+		"-extldflags", "'-Wl,--build-id=0x1122' -static",
+	})
+	qt.Assert(t, qt.DeepEquals(flags, []string{
+		"-other=value",
+		"-extldflags='-Wl,--build-id=0x1122' -static -Wl,--build-id=none",
+	}))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -518,16 +518,34 @@ func TestFlagValue(t *testing.T) {
 
 func TestStripLinkerIdentities(t *testing.T) {
 	t.Parallel()
-	flags := stripLinkerIdentities([]string{
+	input := []string{
 		"-buildid=first-go-identity",
 		"-B", "0x1122",
 		"-other=value",
 		"-buildid", "second-go-identity",
 		"-B=0x3344",
-	})
+	}
+
+	// Nil/non-darwin sharedCache: clear Go build IDs and force -B=none.
+	flags := stripLinkerIdentities(append([]string(nil), input...))
 	qt.Assert(t, qt.Equals(flagValue(flags, "-buildid"), ""))
 	qt.Assert(t, qt.Equals(flagValue(flags, "-B"), "none"))
 	qt.Assert(t, qt.DeepEquals(flags, []string{"-other=value", "-buildid=", "-B=none"}))
+
+	// Darwin must keep LC_UUID, so -B=none must not be forced.
+	prev := sharedCache
+	t.Cleanup(func() { sharedCache = prev })
+	sharedCache = &sharedCacheType{}
+	sharedCache.GoEnv.GOOS = "darwin"
+	flags = stripLinkerIdentities(append([]string(nil), input...))
+	qt.Assert(t, qt.Equals(flagValue(flags, "-buildid"), ""))
+	qt.Assert(t, qt.Equals(flagValue(flags, "-B"), "0x3344"))
+	qt.Assert(t, qt.DeepEquals(flags, []string{
+		"-B", "0x1122",
+		"-other=value",
+		"-B=0x3344",
+		"-buildid=",
+	}))
 }
 
 func TestStripLinuxExternalBuildIDOverride(t *testing.T) {

--- a/testdata/script/cgo.txtar
+++ b/testdata/script/cgo.txtar
@@ -2,9 +2,17 @@
 
 exec garble build
 ! stderr 'warning' # check that the C toolchain is happy
+[linux] ! elfsection main$exe .note.gnu.build-id
 exec ./main
 cmp stdout main.stdout
 ! binsubstr main$exe 'PortedField' 'test/main'
+
+# Force the host-linker path on Linux, including an explicit user build ID
+# which must not override Garble's final no-identity setting.
+[linux] exec garble build -o=main-external$exe -ldflags=-linkmode=external
+[linux] ! elfsection main-external$exe .note.gnu.build-id
+[linux] exec garble build -o=main-external-override$exe -ldflags='-linkmode=external -extldflags=-Wl,--build-id=sha1'
+[linux] ! elfsection main-external-override$exe .note.gnu.build-id
 
 [short] stop # no need to verify this with -short
 

--- a/transformer.go
+++ b/transformer.go
@@ -1509,13 +1509,68 @@ func (tf *transformer) transformLink(args []string) ([]string, error) {
 	// It's the same method as -X, so we can override it with an extra flag.
 	flags = append(flags, "-X=runtime.buildVersion=unknown")
 
-	// Ensure we strip the -buildid flag, to not leak any build IDs for the
-	// link operation or the main package's compilation.
-	flags = flagSetValue(flags, "-buildid", "")
+	flags = stripLinkerIdentities(flags)
 
 	// Strip debug information and symbol tables.
 	flags = append(flags, "-w", "-s")
 
 	flags = flagSetValue(flags, "-importcfg", newImportCfg)
 	return append(flags, args...), nil
+}
+
+// stripLinkerIdentities removes both Go's build ID and the host linker's native
+// identity note. Clearing -buildid alone is insufficient for external ELF
+// links because common GCC specs add a fresh GNU build ID. Go's -B=none is the
+// portable linker-level request for no ELF NT_GNU_BUILD_ID or Mach-O UUID.
+func stripLinkerIdentities(flags []string) []string {
+	flags = flagForceFinalValue(flags, "-buildid", "")
+	flags = flagForceFinalValue(flags, "-B", "none")
+	if sharedCache != nil && sharedCache.GoEnv.GOOS == "linux" {
+		flags = stripLinuxExternalBuildIDOverride(flags)
+	}
+	return flags
+}
+
+// stripLinuxExternalBuildIDOverride prevents an explicit host-linker flag from
+// overriding -B=none later in cmd/link's external-link command. We only add
+// the GNU/LLVM driver spelling when the user already supplied a --build-id
+// option, so unrelated extldflags keep working with unusual Linux linkers.
+func stripLinuxExternalBuildIDOverride(flags []string) []string {
+	value, ok := flagLastValue(flags, "-extldflags")
+	if !ok || !strings.Contains(value, "--build-id") {
+		return flags
+	}
+	value = strings.TrimSpace(value + " -Wl,--build-id=none")
+	return flagForceFinalValue(flags, "-extldflags", value)
+}
+
+func flagLastValue(flags []string, name string) (string, bool) {
+	var value string
+	found := false
+	for value = range flagValues(flags, name) {
+		found = true
+	}
+	return value, found
+}
+
+// flagForceFinalValue removes every joined or separated occurrence before
+// appending one authoritative final value. Go's flag package lets the last
+// repeated string flag win, so merely rewriting the first occurrence leaves a
+// bypass such as "-B=none -B=0x1234".
+func flagForceFinalValue(flags []string, name, value string) []string {
+	result := make([]string, 0, len(flags)+1)
+	for i := 0; i < len(flags); i++ {
+		arg := flags[i]
+		if strings.HasPrefix(arg, name+"=") {
+			continue
+		}
+		if arg == name {
+			if i+1 < len(flags) {
+				i++
+			}
+			continue
+		}
+		result = append(result, arg)
+	}
+	return append(result, name+"="+value)
 }

--- a/transformer.go
+++ b/transformer.go
@@ -1513,13 +1513,68 @@ func (tf *transformer) transformLink(args []string) ([]string, error) {
 	// It's the same method as -X, so we can override it with an extra flag.
 	flags = append(flags, "-X=runtime.buildVersion=unknown")
 
-	// Ensure we strip the -buildid flag, to not leak any build IDs for the
-	// link operation or the main package's compilation.
-	flags = flagSetValue(flags, "-buildid", "")
+	flags = stripLinkerIdentities(flags)
 
 	// Strip debug information and symbol tables.
 	flags = append(flags, "-w", "-s")
 
 	flags = flagSetValue(flags, "-importcfg", newImportCfg)
 	return append(flags, args...), nil
+}
+
+// stripLinkerIdentities removes both Go's build ID and the host linker's native
+// identity note. Clearing -buildid alone is insufficient for external ELF
+// links because common GCC specs add a fresh GNU build ID. Go's -B=none is the
+// portable linker-level request for no ELF NT_GNU_BUILD_ID or Mach-O UUID.
+func stripLinkerIdentities(flags []string) []string {
+	flags = flagForceFinalValue(flags, "-buildid", "")
+	flags = flagForceFinalValue(flags, "-B", "none")
+	if sharedCache != nil && sharedCache.GoEnv.GOOS == "linux" {
+		flags = stripLinuxExternalBuildIDOverride(flags)
+	}
+	return flags
+}
+
+// stripLinuxExternalBuildIDOverride prevents an explicit host-linker flag from
+// overriding -B=none later in cmd/link's external-link command. We only add
+// the GNU/LLVM driver spelling when the user already supplied a --build-id
+// option, so unrelated extldflags keep working with unusual Linux linkers.
+func stripLinuxExternalBuildIDOverride(flags []string) []string {
+	value, ok := flagLastValue(flags, "-extldflags")
+	if !ok || !strings.Contains(value, "--build-id") {
+		return flags
+	}
+	value = strings.TrimSpace(value + " -Wl,--build-id=none")
+	return flagForceFinalValue(flags, "-extldflags", value)
+}
+
+func flagLastValue(flags []string, name string) (string, bool) {
+	var value string
+	found := false
+	for value = range flagValues(flags, name) {
+		found = true
+	}
+	return value, found
+}
+
+// flagForceFinalValue removes every joined or separated occurrence before
+// appending one authoritative final value. Go's flag package lets the last
+// repeated string flag win, so merely rewriting the first occurrence leaves a
+// bypass such as "-B=none -B=0x1234".
+func flagForceFinalValue(flags []string, name, value string) []string {
+	result := make([]string, 0, len(flags)+1)
+	for i := 0; i < len(flags); i++ {
+		arg := flags[i]
+		if strings.HasPrefix(arg, name+"=") {
+			continue
+		}
+		if arg == name {
+			if i+1 < len(flags) {
+				i++
+			}
+			continue
+		}
+		result = append(result, arg)
+	}
+	return append(result, name+"="+value)
 }

--- a/transformer.go
+++ b/transformer.go
@@ -1525,11 +1525,21 @@ func (tf *transformer) transformLink(args []string) ([]string, error) {
 // stripLinkerIdentities removes both Go's build ID and the host linker's native
 // identity note. Clearing -buildid alone is insufficient for external ELF
 // links because common GCC specs add a fresh GNU build ID. Go's -B=none is the
-// portable linker-level request for no ELF NT_GNU_BUILD_ID or Mach-O UUID.
+// linker-level request for no ELF NT_GNU_BUILD_ID (and also no Mach-O UUID).
+//
+// Do not pass -B=none when targeting darwin: modern macOS dyld requires an
+// LC_UUID load command and aborts with "missing LC_UUID load command" if it
+// is absent (burrowers/garble#1058 macOS CI failure).
 func stripLinkerIdentities(flags []string) []string {
 	flags = flagForceFinalValue(flags, "-buildid", "")
-	flags = flagForceFinalValue(flags, "-B", "none")
-	if sharedCache != nil && sharedCache.GoEnv.GOOS == "linux" {
+	goos := ""
+	if sharedCache != nil {
+		goos = sharedCache.GoEnv.GOOS
+	}
+	if goos != "darwin" {
+		flags = flagForceFinalValue(flags, "-B", "none")
+	}
+	if goos == "linux" {
 		flags = stripLinuxExternalBuildIDOverride(flags)
 	}
 	return flags


### PR DESCRIPTION
Clearing Go's `-buildid` is not sufficient when external/native linking adds
its own identity. On Linux this can leave `.note.gnu.build-id`, and a later
user `-extldflags=--build-id=...` can override an earlier suppression flag.

Normalize link flags authoritatively: keep the final Go build ID empty, set
`-B=none`, and on Linux append the final external-linker
`-Wl,--build-id=none` after any user override.