### PR TITLE
suppress direct runtime diagnostic output in tiny mode

### DIFF
--- a/runtime_patch.go
+++ b/runtime_patch.go
@@ -123,7 +123,13 @@ func updateEntryOffset(file *ast.File, entryOffKey uint32) {
 // stripRuntime removes unnecessary code from the runtime,
 // such as panic and fatal error printing, and code that
 // prints trace/debug info of the runtime.
-func stripRuntime(basename string, file *ast.File) {
+func stripRuntime(basename string, file *ast.File) map[string]bool {
+	strippedFunctions := make(map[string]bool)
+	emptyBody := func(funcDecl *ast.FuncDecl) {
+		funcDecl.Body.List = nil
+		strippedFunctions[funcDecl.Name.Name] = true
+	}
+
 	stripPrints := func(node ast.Node) bool {
 		call, ok := node.(*ast.CallExpr)
 		if !ok {
@@ -155,6 +161,19 @@ func stripRuntime(basename string, file *ast.File) {
 			switch funcDecl.Name.Name {
 			case "printany", "printanycustomtype":
 				funcDecl.Body.List = nil
+			}
+		case "debuglog.go":
+			// printDebugLog is called directly from fatal panic and signal
+			// paths. Its implementation can also write through gwrite, so the
+			// generic print/println rewrite below is not sufficient.
+			if funcDecl.Name.Name == "printDebugLog" {
+				emptyBody(funcDecl)
+			}
+		case "hexdump.go":
+			// Go 1.26 moved hexdumpWords out of print.go. It is only used for
+			// fatal GC, signal, and traceback diagnostics in production builds.
+			if funcDecl.Name.Name == "hexdumpWords" {
+				emptyBody(funcDecl)
 			}
 		case "mgcscavenge.go":
 			// used in tracing the scavenger
@@ -190,6 +209,16 @@ func stripRuntime(basename string, file *ast.File) {
 				// sense keeping this function
 				funcDecl.Body.List = nil
 			}
+		case "runtime.go":
+			// writeErrStr bypasses the print builtins and writes fixed fatal
+			// diagnostics straight to stderr (and SetCrashOutput). Tiny mode
+			// already suppresses those same diagnostics through the ordinary
+			// runtime print paths, so suppress this bypass as well. Do not
+			// empty writeErrData or gwrite: application print/println relies on
+			// those lower-level writers.
+			if funcDecl.Name.Name == "writeErrStr" {
+				emptyBody(funcDecl)
+			}
 		case "traceback.go":
 			// only used for printing tracebacks
 			switch funcDecl.Name.Name {
@@ -209,13 +238,30 @@ func stripRuntime(basename string, file *ast.File) {
 
 	if basename == "print.go" {
 		file.Decls = append(file.Decls, hidePrintDecl)
-		return
+		return strippedFunctions
 	}
 
 	// replace all 'print' and 'println' statements in
 	// the runtime with an empty func, which will be
 	// optimized out by the compiler
 	ast.Inspect(file, stripPrints)
+	return strippedFunctions
+}
+
+var requiredDirectRuntimeStrips = map[string][]string{
+	"debuglog.go": {"printDebugLog"},
+	"hexdump.go":  {"hexdumpWords"},
+	"runtime.go":  {"writeErrStr"},
+}
+
+func validateDirectRuntimeStripping(strippedByFile map[string]map[string]bool) {
+	for basename, names := range requiredDirectRuntimeStrips {
+		for _, name := range names {
+			if !strippedByFile[basename][name] {
+				panic("runtime stripping rule did not match " + basename + ":" + name)
+			}
+		}
+	}
 }
 
 var hidePrintDecl = &ast.FuncDecl{

--- a/testdata/script/tiny.txtar
+++ b/testdata/script/tiny.txtar
@@ -1,6 +1,7 @@
 # Tiny mode
 exec garble -tiny build
 ! binsubstr main$exe 'garble_main.go' 'fmt/print.go'
+! binsubstr main$exe 'fatal: morestack on g0'
 ! exec ./main$exe
 stderr '^\(0x[[:xdigit:]]+,0x[[:xdigit:]]+\)' # interfaces/pointers print correctly
 # With -tiny, all line numbers are reset to 1.

--- a/transformer.go
+++ b/transformer.go
@@ -810,6 +810,7 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 	flags = flagSetValue(flags, "-p", tf.curPkg.obfuscatedImportPath())
 
 	newPaths := make([]string, 0, len(files))
+	runtimeStrippedByFile := make(map[string]map[string]bool)
 
 	for i, file := range files {
 		basename := filepath.Base(paths[i])
@@ -818,7 +819,7 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 		case "runtime":
 			if flagTiny {
 				// strip unneeded runtime code
-				stripRuntime(basename, file)
+				runtimeStrippedByFile[basename] = stripRuntime(basename, file)
 				tf.useAllImports(file)
 			}
 			if basename == "symtab.go" {
@@ -854,6 +855,9 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 		if flagDebugDir != "" {
 			debugArtifacts.GarbledFiles[basename] = src
 		}
+	}
+	if tf.curPkg.ImportPath == "runtime" && flagTiny {
+		validateDirectRuntimeStripping(runtimeStrippedByFile)
 	}
 	if err := saveDebugArtifactsForPkg(tf.curPkg, debugCacheKindCompile, debugArtifacts); err != nil {
 		return nil, err


### PR DESCRIPTION
Some runtime diagnostic paths bypass the `print`/`println` calls already
cleaned by tiny mode. Helpers such as direct error writers and debug/hexdump
paths can therefore retain output and diagnostic strings.

Disable only the known diagnostic-only direct-output helpers. Keep lower-level
writers used by application `print`/`println`, and fail closed if the expected
Go runtime source shape changes.