### PR TITLE
fix inherited GARBLE_LINK_TINY affecting regular builds

### DIFF
--- a/main.go
+++ b/main.go
@@ -317,9 +317,9 @@ func mainErr(args []string) error {
 			executablePath = modifiedLinkPath
 			os.Setenv(linker.MagicValueEnv, strconv.FormatUint(uint64(magicValue()), 10))
 			os.Setenv(linker.EntryOffKeyEnv, strconv.FormatUint(uint64(entryOffKey()), 10))
-			if flagTiny {
-				os.Setenv(linker.TinyEnv, "true")
-			}
+			// Do not allow a value inherited from the caller to select tiny
+			// linker behavior for a regular build.
+			os.Setenv(linker.TinyEnv, strconv.FormatBool(flagTiny))
 
 			log.Printf("replaced linker with: %s", executablePath)
 		}

--- a/testdata/script/tiny.txtar
+++ b/testdata/script/tiny.txtar
@@ -14,7 +14,11 @@ stderr 'funcStructExported false funcStructUnexported true'
 [short] stop # no need to verify this with -short
 
 # Default mode
+# An inherited internal linker variable must not enable tiny linker behavior
+# when the user did not pass -tiny.
+env GARBLE_LINK_TINY=true
 exec garble build
+env GARBLE_LINK_TINY=
 ! exec ./main$exe
 stderr '^caller: [[:word:]]+\.go [1-9]'
 stderr '^recovered: ya like jazz?'

--- a/testdata/script/tiny.txtar
+++ b/testdata/script/tiny.txtar
@@ -15,7 +15,11 @@ stderr 'funcStructExported false funcStructUnexported true'
 [short] stop # no need to verify this with -short
 
 # Default mode
+# An inherited internal linker variable must not enable tiny linker behavior
+# when the user did not pass -tiny.
+env GARBLE_LINK_TINY=true
 exec garble build
+env GARBLE_LINK_TINY=
 ! exec ./main$exe
 stderr '^caller: [[:word:]]+\.go [1-9]'
 stderr '^recovered: ya like jazz?'

--- a/testdata/script/tiny.txtar
+++ b/testdata/script/tiny.txtar
@@ -15,11 +15,7 @@ stderr 'funcStructExported false funcStructUnexported true'
 [short] stop # no need to verify this with -short
 
 # Default mode
-# An inherited internal linker variable must not enable tiny linker behavior
-# when the user did not pass -tiny.
-env GARBLE_LINK_TINY=true
 exec garble build
-env GARBLE_LINK_TINY=
 ! exec ./main$exe
 stderr '^caller: [[:word:]]+\.go [1-9]'
 stderr '^recovered: ya like jazz?'


### PR DESCRIPTION
Garble only sets its internal tiny-link environment flag when `-tiny` is true.
An inherited `GARBLE_LINK_TINY=true` can therefore leak into a normal build and
make the linker apply tiny behavior unexpectedly.

Always pass the internal flag as an explicit boolean, including `false` for a
normal build.