### PR TITLE
strip runtime fatal message text in tiny mode

### DIFF
--- a/runtime_patch.go
+++ b/runtime_patch.go
@@ -4,8 +4,10 @@
 package main
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
+	"go/types"
 	"strconv"
 	"strings"
 
@@ -120,10 +122,182 @@ func updateEntryOffset(file *ast.File, entryOffKey uint32) {
 	}
 }
 
+func stripFatalStringFragments(expr ast.Expr) {
+	switch expr := expr.(type) {
+	case *ast.BasicLit:
+		if expr.Kind == token.STRING {
+			expr.Value = `""`
+		}
+	case *ast.ParenExpr:
+		stripFatalStringFragments(expr.X)
+	case *ast.BinaryExpr:
+		if expr.Op == token.ADD {
+			stripFatalStringFragments(expr.X)
+			stripFatalStringFragments(expr.Y)
+		}
+	}
+}
+
+// stripFatalMessageText blanks messages passed to the named package-level
+// functions. Go 1.26 routes a number of standard-library fatal paths into
+// runtime.throw/runtime.fatal via linkname, so limiting this operation to the
+// runtime package leaves those diagnostics in the final binary.
+//
+// Computed expressions are still evaluated to preserve local-variable uses and
+// side effects. Only a zero-length view is passed to the fatal function.
+func stripFatalMessageText(basename string, file *ast.File, info *types.Info, callNames ...string) int {
+	// Package tests can declare local helpers with the same short names. Tiny
+	// mode should only rewrite calls in production source files.
+	if strings.HasSuffix(basename, "_test.go") {
+		return 0
+	}
+
+	matchesName := func(name string) bool {
+		for _, callName := range callNames {
+			if name == callName {
+				return true
+			}
+		}
+		return false
+	}
+
+	stripped := 0
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || len(call.Args) != 1 {
+			return true
+		}
+		id, ok := call.Fun.(*ast.Ident)
+		if !ok || !matchesName(id.Name) {
+			return true
+		}
+		if info != nil {
+			obj := info.Uses[id]
+			if obj == nil || obj.Pkg() == nil || obj.Parent() != obj.Pkg().Scope() {
+				// A local shadow with the same short name is unrelated to the
+				// package-level function or variable wired into the runtime.
+				return true
+			}
+		}
+		message := call.Args[0]
+		stripFatalStringFragments(message)
+		if literal, ok := message.(*ast.BasicLit); ok && literal.Kind == token.STRING {
+			literal.Value = `""`
+		} else {
+			call.Args[0] = &ast.SliceExpr{
+				X:    &ast.ParenExpr{X: message},
+				High: &ast.BasicLit{Kind: token.INT, Value: "0"},
+			}
+		}
+		stripped++
+		return false
+	})
+	return stripped
+}
+
+type runtimeDependencyStrips struct {
+	fatalMessages int
+	cgroupPrints  int
+}
+
+// These functions are either linknamed to runtime.throw/runtime.fatal or, in
+// exithook's case, populated with runtime.throw during runtime initialization.
+// Keep the allowlist exact: rewriting an arbitrary function named fatal in a
+// normal package would be an unacceptable semantic change.
+var runtimeFatalCallNames = map[string][]string{
+	"crypto/internal/fips140":   {"fatal"},
+	"crypto/internal/sysrand":   {"fatal"},
+	"crypto/rand":               {"fatal"},
+	"internal/runtime/cgroup":   {"throw"},
+	"internal/runtime/exithook": {"Throw"},
+	"internal/runtime/maps":     {"fatal"},
+	"internal/sync":             {"throw", "fatal"},
+	"sync":                      {"throw", "fatal"},
+}
+
+var requiredRuntimeFatalMessageCounts = map[string]int{
+	"crypto/internal/fips140":   2,
+	"crypto/internal/sysrand":   1,
+	"crypto/rand":               1,
+	"internal/runtime/cgroup":   6,
+	"internal/runtime/exithook": 2,
+	"internal/runtime/maps":     42,
+	"internal/sync":             3,
+	"sync":                      5,
+}
+
+// stripCgroupFatalPrint removes the one Linux cgroup diagnostic which writes
+// directly through the print builtin immediately before calling runtime.throw.
+// Its replacement has the same concrete parameter types, so all arguments are
+// still evaluated without adding interface conversions or a package-level
+// declaration. The exact shape deliberately fails closed if Go changes it.
+func stripCgroupFatalPrint(basename string, file *ast.File) int {
+	if basename != "cgroup_linux.go" {
+		return 0
+	}
+	stripped := 0
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || len(call.Args) != 4 {
+			return true
+		}
+		id, ok := call.Fun.(*ast.Ident)
+		if !ok || id.Name != "println" {
+			return true
+		}
+		first, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || first.Kind != token.STRING || first.Value != `"runtime: cgroup buffer length"` {
+			return true
+		}
+		third, ok := call.Args[2].(*ast.BasicLit)
+		if !ok || third.Kind != token.STRING || third.Value != `"want"` {
+			return true
+		}
+		first.Value = `""`
+		third.Value = `""`
+		call.Fun = &ast.FuncLit{
+			Type: &ast.FuncType{Params: &ast.FieldList{List: []*ast.Field{
+				{Type: ast.NewIdent("string")},
+				{Type: ast.NewIdent("int")},
+				{Type: ast.NewIdent("string")},
+				{Type: ast.NewIdent("int")},
+			}}},
+			Body: &ast.BlockStmt{},
+		}
+		stripped++
+		return false
+	})
+	return stripped
+}
+
+func stripRuntimeDependency(importPath, basename string, file *ast.File, info *types.Info) runtimeDependencyStrips {
+	var result runtimeDependencyStrips
+	result.fatalMessages = stripFatalMessageText(basename, file, info, runtimeFatalCallNames[importPath]...)
+	if importPath == "internal/runtime/cgroup" {
+		result.cgroupPrints = stripCgroupFatalPrint(basename, file)
+	}
+	return result
+}
+
+func validateRuntimeDependencyStripping(importPath string, strippedByFile map[string]runtimeDependencyStrips) {
+	var totals runtimeDependencyStrips
+	for _, result := range strippedByFile {
+		totals.fatalMessages += result.fatalMessages
+		totals.cgroupPrints += result.cgroupPrints
+	}
+	want := requiredRuntimeFatalMessageCounts[importPath]
+	if totals.fatalMessages != want {
+		panic(fmt.Sprintf("runtime-linked fatal stripping matched %d calls in %s, want %d", totals.fatalMessages, importPath, want))
+	}
+	if importPath == "internal/runtime/cgroup" && totals.cgroupPrints != 1 {
+		panic(fmt.Sprintf("runtime cgroup print stripping matched %d calls, want 1", totals.cgroupPrints))
+	}
+}
+
 // stripRuntime removes unnecessary code from the runtime,
 // such as panic and fatal error printing, and code that
 // prints trace/debug info of the runtime.
-func stripRuntime(basename string, file *ast.File) {
+func stripRuntime(basename string, file *ast.File, info *types.Info) {
 	stripPrints := func(node ast.Node) bool {
 		call, ok := node.(*ast.CallExpr)
 		if !ok {
@@ -207,7 +381,11 @@ func stripRuntime(basename string, file *ast.File) {
 
 	}
 
+	stripFatalMessageText(basename, file, info, "throw", "fatal")
 	if basename == "print.go" {
+		// print.go implements application-facing print/println support; rewriting
+		// its internal calls breaks interface and pointer formatting. The helper
+		// declaration is needed by calls rewritten in the other runtime files.
 		file.Decls = append(file.Decls, hidePrintDecl)
 		return
 	}

--- a/runtime_patch.go
+++ b/runtime_patch.go
@@ -6,6 +6,7 @@ package main
 import (
 	"go/ast"
 	"go/token"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -118,6 +119,66 @@ func updateEntryOffset(file *ast.File, entryOffKey uint32) {
 	if !entryOffUpdated {
 		panic("entryOff not found")
 	}
+}
+
+func stripFatalStringFragments(expr ast.Expr) {
+	switch expr := expr.(type) {
+	case *ast.BasicLit:
+		if expr.Kind == token.STRING {
+			expr.Value = `""`
+		}
+	case *ast.ParenExpr:
+		stripFatalStringFragments(expr.X)
+	case *ast.BinaryExpr:
+		if expr.Op == token.ADD {
+			stripFatalStringFragments(expr.X)
+			stripFatalStringFragments(expr.Y)
+		}
+	}
+}
+
+// runtimeFatalCalls lists, per package, the diagnostic functions whose string
+// arguments are blanked in tiny mode. In the standard library these are
+// linknamed to [runtime.throw]/runtime.fatal (or, for exithook, populated with
+// [runtime.throw] at init), so garble's runtime-only cleanup would otherwise
+// leave their messages in the binary; cgroup also prints one such message
+// through the print builtins. The names are kept exact because in these
+// packages every such call is a crash diagnostic whose message is throwaway.
+var runtimeFatalCalls = map[string][]string{
+	"runtime":                   {"throw", "fatal"},
+	"crypto/internal/fips140":   {"fatal"},
+	"crypto/internal/sysrand":   {"fatal"},
+	"crypto/rand":               {"fatal"},
+	"internal/runtime/cgroup":   {"throw", "print", "println"},
+	"internal/runtime/exithook": {"Throw"},
+	"internal/runtime/maps":     {"fatal"},
+	"internal/sync":             {"throw", "fatal"},
+	"sync":                      {"throw", "fatal"},
+}
+
+// stripFatalMessages blanks the static string fragments passed to the diagnostic
+// functions named for importPath. Non-literal arguments keep being evaluated, so
+// their local uses and side effects are preserved; only the embedded text is
+// removed, and tiny mode already suppresses the runtime's fatal output.
+func stripFatalMessages(importPath string, file *ast.File) {
+	callNames := runtimeFatalCalls[importPath]
+	if callNames == nil {
+		return
+	}
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		id, ok := call.Fun.(*ast.Ident)
+		if !ok || !slices.Contains(callNames, id.Name) {
+			return true
+		}
+		for _, arg := range call.Args {
+			stripFatalStringFragments(arg)
+		}
+		return true
+	})
 }
 
 // stripRuntime removes unnecessary code from the runtime,

--- a/runtime_patch_test.go
+++ b/runtime_patch_test.go
@@ -1,0 +1,220 @@
+// Copyright (c) 2026, The Garble Authors.
+// See LICENSE for licensing information.
+
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+)
+
+func TestStripRuntimeFatalMessageText(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "synthetic.go", `package runtime
+func f(name string) {
+	throw("literal diagnostic")
+	throw(name)
+	throw("prefix " + name)
+	throw("before " + sideEffect() + " after")
+}
+`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stripRuntime("synthetic.go", file, nil)
+
+	var args []ast.Expr
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		id, ok := call.Fun.(*ast.Ident)
+		if ok && id.Name == "throw" {
+			args = append(args, call.Args[0])
+			return false
+		}
+		return true
+	})
+	if len(args) != 4 {
+		t.Fatalf("found %d throw arguments, want 4", len(args))
+	}
+	if literal, ok := args[0].(*ast.BasicLit); !ok || literal.Kind != token.STRING || literal.Value != `""` {
+		t.Fatalf("direct literal was not blanked: %#v", args[0])
+	}
+
+	for i, arg := range args[1:] {
+		slice, ok := arg.(*ast.SliceExpr)
+		if !ok {
+			t.Fatalf("computed argument %d is %T, want *ast.SliceExpr", i+1, arg)
+		}
+		high, ok := slice.High.(*ast.BasicLit)
+		if !ok || high.Kind != token.INT || high.Value != "0" {
+			t.Fatalf("computed argument %d does not use [:0]", i+1)
+		}
+		ast.Inspect(slice.X, func(node ast.Node) bool {
+			if literal, ok := node.(*ast.BasicLit); ok && literal.Kind == token.STRING && literal.Value != `""` {
+				t.Errorf("computed argument %d retained static fragment %s", i+1, literal.Value)
+			}
+			return true
+		})
+	}
+
+	var sawName, sawSideEffect bool
+	ast.Inspect(args[2], func(node ast.Node) bool {
+		if id, ok := node.(*ast.Ident); ok && id.Name == "name" {
+			sawName = true
+		}
+		return true
+	})
+	ast.Inspect(args[3], func(node ast.Node) bool {
+		if call, ok := node.(*ast.CallExpr); ok {
+			if id, ok := call.Fun.(*ast.Ident); ok && id.Name == "sideEffect" {
+				sawSideEffect = true
+			}
+		}
+		return true
+	})
+	if !sawName || !sawSideEffect {
+		t.Fatalf("computed evaluation was lost: name=%v sideEffect=%v", sawName, sawSideEffect)
+	}
+}
+
+func TestStripRuntimeLeavesTestFatalHelpersAlone(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "synthetic_test.go", `package runtime
+func testHelper() { fatal("test-owned diagnostic") }
+`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stripRuntime("synthetic_test.go", file, nil)
+
+	found := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		literal, ok := node.(*ast.BasicLit)
+		if ok && literal.Kind == token.STRING && literal.Value == `"test-owned diagnostic"` {
+			found = true
+		}
+		return true
+	})
+	if !found {
+		t.Fatal("runtime test helper diagnostic was unexpectedly changed")
+	}
+}
+
+func TestStripRuntimeLinkedFatalPackages(t *testing.T) {
+	for importPath, callNames := range runtimeFatalCallNames {
+		t.Run(importPath, func(t *testing.T) {
+			var source strings.Builder
+			source.WriteString("package synthetic\nfunc f(message string, size int) {\n")
+			if importPath == "internal/runtime/cgroup" {
+				source.WriteString("println(\"runtime: cgroup buffer length\", len(message), \"want\", size)\n")
+			}
+			for _, callName := range callNames {
+				source.WriteString(callName + "(\"diagnostic prefix: \" + message)\n")
+			}
+			source.WriteString("}\n")
+
+			basename := "synthetic.go"
+			if importPath == "internal/runtime/cgroup" {
+				basename = "cgroup_linux.go"
+			}
+			file, err := parser.ParseFile(token.NewFileSet(), basename, source.String(), 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			result := stripRuntimeDependency(importPath, basename, file, nil)
+			if result.fatalMessages != len(callNames) {
+				t.Fatalf("stripped %d fatal messages, want %d", result.fatalMessages, len(callNames))
+			}
+			if importPath == "internal/runtime/cgroup" && result.cgroupPrints != 1 {
+				t.Fatalf("stripped %d cgroup prints, want 1", result.cgroupPrints)
+			}
+
+			ast.Inspect(file, func(node ast.Node) bool {
+				literal, ok := node.(*ast.BasicLit)
+				if ok && literal.Kind == token.STRING {
+					if strings.Contains(literal.Value, "diagnostic prefix") || strings.Contains(literal.Value, "cgroup buffer") {
+						t.Errorf("diagnostic string survived: %s", literal.Value)
+					}
+				}
+				return true
+			})
+		})
+	}
+}
+
+func TestStripCgroupFatalPrintPreservesConcreteEvaluation(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "cgroup_linux.go", `package cgroup
+func f(s []byte, size int) {
+	println("runtime: cgroup buffer length", len(s), "want", size)
+}
+`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := stripCgroupFatalPrint("cgroup_linux.go", file); got != 1 {
+		t.Fatalf("stripped %d calls, want 1", got)
+	}
+
+	var replacement *ast.CallExpr
+	ast.Inspect(file, func(node ast.Node) bool {
+		if call, ok := node.(*ast.CallExpr); ok {
+			if _, ok := call.Fun.(*ast.FuncLit); ok {
+				replacement = call
+				return false
+			}
+		}
+		return true
+	})
+	if replacement == nil || len(replacement.Args) != 4 {
+		t.Fatalf("missing four-argument no-op replacement: %#v", replacement)
+	}
+	if call, ok := replacement.Args[1].(*ast.CallExpr); !ok {
+		t.Fatalf("len(s) evaluation was lost: %T", replacement.Args[1])
+	} else if id, ok := call.Fun.(*ast.Ident); !ok || id.Name != "len" {
+		t.Fatalf("len(s) evaluation changed: %#v", call.Fun)
+	}
+}
+
+func TestStripFatalMessageTextIgnoresLocalShadow(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "synthetic.go", `package synthetic
+func fatal(string)
+func packageCall() { fatal("package diagnostic") }
+func localCall() {
+	fatal := func(string) {}
+	fatal("local diagnostic")
+}
+`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info := &types.Info{
+		Defs: make(map[*ast.Ident]types.Object),
+		Uses: make(map[*ast.Ident]types.Object),
+	}
+	if _, err := (&types.Config{}).Check("synthetic", fset, []*ast.File{file}, info); err != nil {
+		t.Fatal(err)
+	}
+	if got := stripFatalMessageText("synthetic.go", file, info, "fatal"); got != 1 {
+		t.Fatalf("stripped %d calls, want only the package-level call", got)
+	}
+
+	var foundPackage, foundLocal bool
+	ast.Inspect(file, func(node ast.Node) bool {
+		literal, ok := node.(*ast.BasicLit)
+		if !ok || literal.Kind != token.STRING {
+			return true
+		}
+		foundPackage = foundPackage || literal.Value == `"package diagnostic"`
+		foundLocal = foundLocal || literal.Value == `"local diagnostic"`
+		return true
+	})
+	if foundPackage || !foundLocal {
+		t.Fatalf("package/local diagnostics after stripping: package=%v local=%v", foundPackage, foundLocal)
+	}
+}

--- a/testdata/script/tiny.txtar
+++ b/testdata/script/tiny.txtar
@@ -1,6 +1,13 @@
 # Tiny mode
 exec garble -tiny build
 ! binsubstr main$exe 'garble_main.go' 'fmt/print.go'
+! binsubstr main$exe 'all goroutines are asleep - deadlock!' 'no goroutines (main called runtime.Goexit) - deadlock!'
+! binsubstr main$exe 'panicwrap: no ( in ' 'unpinned Go pointer stored into non-Go memory'
+! binsubstr main$exe 'runtime: unexpected metric registration for ' 'runtime.SetFinalizer: first argument is '
+! binsubstr main$exe 'concurrent map writes' 'exit hook invoked exit'
+! binsubstr main$exe 'sync: unlock of unlocked mutex' 'sync: RUnlock of unlocked RWMutex'
+! binsubstr main$exe 'crypto/rand: failed to read random data' 'FIPS 140-3 self-test failed'
+[linux] ! binsubstr main$exe 'impossible cgroup version' 'runtime: cgroup buffer length'
 ! exec ./main$exe
 stderr '^\(0x[[:xdigit:]]+,0x[[:xdigit:]]+\)' # interfaces/pointers print correctly
 # With -tiny, all line numbers are reset to 1.
@@ -29,8 +36,10 @@ go 1.23
 package main
 
 import (
+	cryptorand "crypto/rand"
 	"reflect"
 	"runtime"
+	"sync"
 )
 
 type testStruct struct{}
@@ -49,6 +58,22 @@ func isEmptyFuncName(i interface{}) bool {
 }
 
 func main() {
+	// Retain fatal paths which Go 1.26 moved into runtime-linked standard
+	// packages. They must be cleaned even though these branches never execute.
+	if runtime.NumCPU() < 0 {
+		_, _ = cryptorand.Read(nil)
+		var mutex sync.Mutex
+		mutex.Unlock()
+		var rwmutex sync.RWMutex
+		rwmutex.Unlock()
+	}
+
+	// Keep SetFinalizer's computed fatal paths linked so the binary scan above
+	// verifies that tiny removes fragments around side-effectful expressions.
+	if runtime.NumCPU() < 0 {
+		runtime.SetFinalizer(nil, nil)
+	}
+
 	println("funcExported", isEmptyFuncName(ExportedFunc), "funcUnexported", isEmptyFuncName(unexportedFunc))
 
 	var s testStruct

--- a/testdata/script/tiny.txtar
+++ b/testdata/script/tiny.txtar
@@ -2,6 +2,13 @@
 exec garble -tiny build
 ! binsubstr main$exe 'garble_main.go' 'fmt/print.go'
 ! binsubstr main$exe 'fatal: morestack on g0'
+! binsubstr main$exe 'all goroutines are asleep - deadlock!' 'no goroutines (main called runtime.Goexit) - deadlock!'
+! binsubstr main$exe 'panicwrap: no ( in ' 'unpinned Go pointer stored into non-Go memory'
+! binsubstr main$exe 'runtime: unexpected metric registration for ' 'runtime.SetFinalizer: first argument is '
+! binsubstr main$exe 'concurrent map writes' 'exit hook invoked exit'
+! binsubstr main$exe 'sync: unlock of unlocked mutex' 'sync: RUnlock of unlocked RWMutex'
+! binsubstr main$exe 'crypto/rand: failed to read random data' 'FIPS 140-3 self-test failed'
+[linux] ! binsubstr main$exe 'impossible cgroup version' 'runtime: cgroup buffer length'
 ! exec ./main$exe
 stderr '^\(0x[[:xdigit:]]+,0x[[:xdigit:]]+\)' # interfaces/pointers print correctly
 # With -tiny, all line numbers are reset to 1.
@@ -32,8 +39,10 @@ go 1.23
 package main
 
 import (
+	cryptorand "crypto/rand"
 	"reflect"
 	"runtime"
+	"sync"
 )
 
 type testStruct struct{}
@@ -52,6 +61,21 @@ func isEmptyFuncName(i interface{}) bool {
 }
 
 func main() {
+	// Retain fatal paths which Go 1.26 moved into runtime-linked standard
+	// packages, plus SetFinalizer's computed fatal paths. They must be cleaned
+	// even though these branches never execute; SetFinalizer also lets the scan
+	// verify that fragments around side-effectful expressions are removed.
+	if runtime.NumCPU() < 0 {
+		_, _ = cryptorand.Read(nil)
+		var mutex sync.Mutex
+		mutex.Unlock()
+		var rwmutex sync.RWMutex
+		// Call RUnlock so the binary retains the RWMutex diagnostic fragment
+		// that binsubstr asserts is stripped above.
+		rwmutex.RUnlock()
+		runtime.SetFinalizer(nil, nil)
+	}
+
 	println("funcExported", isEmptyFuncName(ExportedFunc), "funcUnexported", isEmptyFuncName(unexportedFunc))
 
 	var s testStruct

--- a/transformer.go
+++ b/transformer.go
@@ -810,6 +810,7 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 	flags = flagSetValue(flags, "-p", tf.curPkg.obfuscatedImportPath())
 
 	newPaths := make([]string, 0, len(files))
+	runtimeDependencyStrippedByFile := make(map[string]runtimeDependencyStrips)
 
 	for i, file := range files {
 		basename := filepath.Base(paths[i])
@@ -818,7 +819,7 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 		case "runtime":
 			if flagTiny {
 				// strip unneeded runtime code
-				stripRuntime(basename, file)
+				stripRuntime(basename, file, tf.info)
 				tf.useAllImports(file)
 			}
 			if basename == "symtab.go" {
@@ -827,6 +828,11 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 		case "internal/abi":
 			if basename == "symtab.go" {
 				updateMagicValue(file, magicValue())
+			}
+		}
+		if flagTiny {
+			if _, ok := runtimeFatalCallNames[tf.curPkg.ImportPath]; ok {
+				runtimeDependencyStrippedByFile[basename] = stripRuntimeDependency(tf.curPkg.ImportPath, basename, file, tf.info)
 			}
 		}
 		if err := tf.transformDirectives(file.Comments); err != nil {
@@ -853,6 +859,11 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 		}
 		if flagDebugDir != "" {
 			debugArtifacts.GarbledFiles[basename] = src
+		}
+	}
+	if flagTiny {
+		if _, ok := runtimeFatalCallNames[tf.curPkg.ImportPath]; ok {
+			validateRuntimeDependencyStripping(tf.curPkg.ImportPath, runtimeDependencyStrippedByFile)
 		}
 	}
 	if err := saveDebugArtifactsForPkg(tf.curPkg, debugCacheKindCompile, debugArtifacts); err != nil {

--- a/transformer.go
+++ b/transformer.go
@@ -839,6 +839,9 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 				updateMagicValue(file, magicValue())
 			}
 		}
+		if flagTiny {
+			stripFatalMessages(tf.curPkg.ImportPath, file)
+		}
 		if err := tf.transformDirectives(file.Comments); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Go 1.26 routes fatal paths through both `runtime` and runtime-linked standard
packages. Tiny's current runtime-only cleanup leaves many messages in binaries,
including crypto, maps, sync, exithook, and cgroup diagnostics.

Blank static message fragments for an exact package/function allowlist while
still evaluating computed expressions and side effects. Validate exact match
counts so a Go source change fails closed instead of silently broadening or
missing cleanup.