### PR TITLE
remove Linux runtime VMA labels in tiny mode

### DIFF
--- a/runtime_patch.go
+++ b/runtime_patch.go
@@ -123,7 +123,8 @@ func updateEntryOffset(file *ast.File, entryOffKey uint32) {
 // stripRuntime removes unnecessary code from the runtime,
 // such as panic and fatal error printing, and code that
 // prints trace/debug info of the runtime.
-func stripRuntime(basename string, file *ast.File) {
+func stripRuntime(basename string, file *ast.File) bool {
+	strippedVMAName := false
 	stripPrints := func(node ast.Node) bool {
 		call, ok := node.(*ast.CallExpr)
 		if !ok {
@@ -190,6 +191,14 @@ func stripRuntime(basename string, file *ast.File) {
 				// sense keeping this function
 				funcDecl.Body.List = nil
 			}
+		case "set_vma_name_linux.go":
+			// Linux exposes anonymous VMA names through /proc/PID/maps. They are
+			// diagnostic-only labels such as "Go: heap arena", not correctness
+			// metadata, and would otherwise remain as an OS-visible runtime trace.
+			if funcDecl.Name.Name == "setVMAName" {
+				funcDecl.Body.List = nil
+				strippedVMAName = true
+			}
 		case "traceback.go":
 			// only used for printing tracebacks
 			switch funcDecl.Name.Name {
@@ -209,13 +218,14 @@ func stripRuntime(basename string, file *ast.File) {
 
 	if basename == "print.go" {
 		file.Decls = append(file.Decls, hidePrintDecl)
-		return
+		return strippedVMAName
 	}
 
 	// replace all 'print' and 'println' statements in
 	// the runtime with an empty func, which will be
 	// optimized out by the compiler
 	ast.Inspect(file, stripPrints)
+	return strippedVMAName
 }
 
 var hidePrintDecl = &ast.FuncDecl{

--- a/runtime_patch.go
+++ b/runtime_patch.go
@@ -123,8 +123,16 @@ func updateEntryOffset(file *ast.File, entryOffKey uint32) {
 // stripRuntime removes unnecessary code from the runtime,
 // such as panic and fatal error printing, and code that
 // prints trace/debug info of the runtime.
-func stripRuntime(basename string, file *ast.File) bool {
-	strippedVMAName := false
+//
+// strippedVMAName is a named result so callers can tell it apart from a
+// general success/failure flag: it is set only when setVMAName was emptied.
+func stripRuntime(basename string, file *ast.File) (strippedFunctions map[string]bool, strippedVMAName bool) {
+	strippedFunctions = make(map[string]bool)
+	emptyBody := func(funcDecl *ast.FuncDecl) {
+		funcDecl.Body.List = nil
+		strippedFunctions[funcDecl.Name.Name] = true
+	}
+
 	stripPrints := func(node ast.Node) bool {
 		call, ok := node.(*ast.CallExpr)
 		if !ok {
@@ -156,6 +164,19 @@ func stripRuntime(basename string, file *ast.File) bool {
 			switch funcDecl.Name.Name {
 			case "printany", "printanycustomtype":
 				funcDecl.Body.List = nil
+			}
+		case "debuglog.go":
+			// printDebugLog is called directly from fatal panic and signal
+			// paths. Its implementation can also write through gwrite, so the
+			// generic print/println rewrite below is not sufficient.
+			if funcDecl.Name.Name == "printDebugLog" {
+				emptyBody(funcDecl)
+			}
+		case "hexdump.go":
+			// Go 1.26 moved hexdumpWords out of print.go. It is only used for
+			// fatal GC, signal, and traceback diagnostics in production builds.
+			if funcDecl.Name.Name == "hexdumpWords" {
+				emptyBody(funcDecl)
 			}
 		case "mgcscavenge.go":
 			// used in tracing the scavenger
@@ -191,12 +212,22 @@ func stripRuntime(basename string, file *ast.File) bool {
 				// sense keeping this function
 				funcDecl.Body.List = nil
 			}
+		case "runtime.go":
+			// writeErrStr bypasses the print builtins and writes fixed fatal
+			// diagnostics straight to stderr (and SetCrashOutput). Tiny mode
+			// already suppresses those same diagnostics through the ordinary
+			// runtime print paths, so suppress this bypass as well. Do not
+			// empty writeErrData or gwrite: application print/println relies on
+			// those lower-level writers.
+			if funcDecl.Name.Name == "writeErrStr" {
+				emptyBody(funcDecl)
+			}
 		case "set_vma_name_linux.go":
 			// Linux exposes anonymous VMA names through /proc/PID/maps. They are
 			// diagnostic-only labels such as "Go: heap arena", not correctness
 			// metadata, and would otherwise remain as an OS-visible runtime trace.
 			if funcDecl.Name.Name == "setVMAName" {
-				funcDecl.Body.List = nil
+				emptyBody(funcDecl)
 				strippedVMAName = true
 			}
 		case "traceback.go":
@@ -218,14 +249,30 @@ func stripRuntime(basename string, file *ast.File) bool {
 
 	if basename == "print.go" {
 		file.Decls = append(file.Decls, hidePrintDecl)
-		return strippedVMAName
+		return strippedFunctions, strippedVMAName
 	}
 
 	// replace all 'print' and 'println' statements in
 	// the runtime with an empty func, which will be
 	// optimized out by the compiler
 	ast.Inspect(file, stripPrints)
-	return strippedVMAName
+	return strippedFunctions, strippedVMAName
+}
+
+var requiredDirectRuntimeStrips = map[string][]string{
+	"debuglog.go": {"printDebugLog"},
+	"hexdump.go":  {"hexdumpWords"},
+	"runtime.go":  {"writeErrStr"},
+}
+
+func validateDirectRuntimeStripping(strippedByFile map[string]map[string]bool) {
+	for basename, names := range requiredDirectRuntimeStrips {
+		for _, name := range names {
+			if !strippedByFile[basename][name] {
+				panic("runtime stripping rule did not match " + basename + ":" + name)
+			}
+		}
+	}
 }
 
 var hidePrintDecl = &ast.FuncDecl{

--- a/runtime_patch.go
+++ b/runtime_patch.go
@@ -123,13 +123,8 @@ func updateEntryOffset(file *ast.File, entryOffKey uint32) {
 // stripRuntime removes unnecessary code from the runtime,
 // such as panic and fatal error printing, and code that
 // prints trace/debug info of the runtime.
-func stripRuntime(basename string, file *ast.File) map[string]bool {
-	strippedFunctions := make(map[string]bool)
-	emptyBody := func(funcDecl *ast.FuncDecl) {
-		funcDecl.Body.List = nil
-		strippedFunctions[funcDecl.Name.Name] = true
-	}
-
+func stripRuntime(basename string, file *ast.File) bool {
+	strippedVMAName := false
 	stripPrints := func(node ast.Node) bool {
 		call, ok := node.(*ast.CallExpr)
 		if !ok {
@@ -161,19 +156,6 @@ func stripRuntime(basename string, file *ast.File) map[string]bool {
 			switch funcDecl.Name.Name {
 			case "printany", "printanycustomtype":
 				funcDecl.Body.List = nil
-			}
-		case "debuglog.go":
-			// printDebugLog is called directly from fatal panic and signal
-			// paths. Its implementation can also write through gwrite, so the
-			// generic print/println rewrite below is not sufficient.
-			if funcDecl.Name.Name == "printDebugLog" {
-				emptyBody(funcDecl)
-			}
-		case "hexdump.go":
-			// Go 1.26 moved hexdumpWords out of print.go. It is only used for
-			// fatal GC, signal, and traceback diagnostics in production builds.
-			if funcDecl.Name.Name == "hexdumpWords" {
-				emptyBody(funcDecl)
 			}
 		case "mgcscavenge.go":
 			// used in tracing the scavenger
@@ -209,15 +191,13 @@ func stripRuntime(basename string, file *ast.File) map[string]bool {
 				// sense keeping this function
 				funcDecl.Body.List = nil
 			}
-		case "runtime.go":
-			// writeErrStr bypasses the print builtins and writes fixed fatal
-			// diagnostics straight to stderr (and SetCrashOutput). Tiny mode
-			// already suppresses those same diagnostics through the ordinary
-			// runtime print paths, so suppress this bypass as well. Do not
-			// empty writeErrData or gwrite: application print/println relies on
-			// those lower-level writers.
-			if funcDecl.Name.Name == "writeErrStr" {
-				emptyBody(funcDecl)
+		case "set_vma_name_linux.go":
+			// Linux exposes anonymous VMA names through /proc/PID/maps. They are
+			// diagnostic-only labels such as "Go: heap arena", not correctness
+			// metadata, and would otherwise remain as an OS-visible runtime trace.
+			if funcDecl.Name.Name == "setVMAName" {
+				funcDecl.Body.List = nil
+				strippedVMAName = true
 			}
 		case "traceback.go":
 			// only used for printing tracebacks
@@ -238,30 +218,14 @@ func stripRuntime(basename string, file *ast.File) map[string]bool {
 
 	if basename == "print.go" {
 		file.Decls = append(file.Decls, hidePrintDecl)
-		return strippedFunctions
+		return strippedVMAName
 	}
 
 	// replace all 'print' and 'println' statements in
 	// the runtime with an empty func, which will be
 	// optimized out by the compiler
 	ast.Inspect(file, stripPrints)
-	return strippedFunctions
-}
-
-var requiredDirectRuntimeStrips = map[string][]string{
-	"debuglog.go": {"printDebugLog"},
-	"hexdump.go":  {"hexdumpWords"},
-	"runtime.go":  {"writeErrStr"},
-}
-
-func validateDirectRuntimeStripping(strippedByFile map[string]map[string]bool) {
-	for basename, names := range requiredDirectRuntimeStrips {
-		for _, name := range names {
-			if !strippedByFile[basename][name] {
-				panic("runtime stripping rule did not match " + basename + ":" + name)
-			}
-		}
-	}
+	return strippedVMAName
 }
 
 var hidePrintDecl = &ast.FuncDecl{

--- a/testdata/script/tiny-vma.txtar
+++ b/testdata/script/tiny-vma.txtar
@@ -1,0 +1,15 @@
+# Linux exposes Go runtime VMA labels via /proc/PID/maps. Cross-build on every
+# host so this cleanup does not silently lose coverage on Windows or macOS.
+env GOOS=linux
+env GOARCH=amd64
+exec garble -tiny build -o=main
+! binsubstr main ' Go: '
+
+-- go.mod --
+module test/main
+
+go 1.23
+-- main.go --
+package main
+
+func main() {}

--- a/testdata/script/tiny-vma.txtar
+++ b/testdata/script/tiny-vma.txtar
@@ -3,7 +3,7 @@
 env GOOS=linux
 env GOARCH=amd64
 exec garble -tiny build -o=main
-! binsubstr main ' Go: '
+! binsubstr main 'Go:'
 
 -- go.mod --
 module test/main

--- a/transformer.go
+++ b/transformer.go
@@ -810,6 +810,7 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 	flags = flagSetValue(flags, "-p", tf.curPkg.obfuscatedImportPath())
 
 	newPaths := make([]string, 0, len(files))
+	runtimeVMAStrippedByFile := make(map[string]bool)
 
 	for i, file := range files {
 		basename := filepath.Base(paths[i])
@@ -818,7 +819,7 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 		case "runtime":
 			if flagTiny {
 				// strip unneeded runtime code
-				stripRuntime(basename, file)
+				runtimeVMAStrippedByFile[basename] = stripRuntime(basename, file)
 				tf.useAllImports(file)
 			}
 			if basename == "symtab.go" {
@@ -853,6 +854,11 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 		}
 		if flagDebugDir != "" {
 			debugArtifacts.GarbledFiles[basename] = src
+		}
+	}
+	if tf.curPkg.ImportPath == "runtime" && flagTiny && sharedCache.GoEnv.GOOS == "linux" {
+		if !runtimeVMAStrippedByFile["set_vma_name_linux.go"] {
+			panic("runtime stripping rule did not match set_vma_name_linux.go:setVMAName")
 		}
 	}
 	if err := saveDebugArtifactsForPkg(tf.curPkg, debugCacheKindCompile, debugArtifacts); err != nil {

--- a/transformer.go
+++ b/transformer.go
@@ -810,7 +810,7 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 	flags = flagSetValue(flags, "-p", tf.curPkg.obfuscatedImportPath())
 
 	newPaths := make([]string, 0, len(files))
-	runtimeVMAStrippedByFile := make(map[string]bool)
+	runtimeStrippedByFile := make(map[string]map[string]bool)
 
 	for i, file := range files {
 		basename := filepath.Base(paths[i])
@@ -819,7 +819,11 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 		case "runtime":
 			if flagTiny {
 				// strip unneeded runtime code
-				runtimeVMAStrippedByFile[basename] = stripRuntime(basename, file)
+				strippedFunctions, strippedVMAName := stripRuntime(basename, file)
+				runtimeStrippedByFile[basename] = strippedFunctions
+				if basename == "set_vma_name_linux.go" && sharedCache.GoEnv.GOOS == "linux" && !strippedVMAName {
+					panic("runtime stripping rule did not match set_vma_name_linux.go:setVMAName")
+				}
 				tf.useAllImports(file)
 			}
 			if basename == "symtab.go" {
@@ -856,10 +860,8 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 			debugArtifacts.GarbledFiles[basename] = src
 		}
 	}
-	if tf.curPkg.ImportPath == "runtime" && flagTiny && sharedCache.GoEnv.GOOS == "linux" {
-		if !runtimeVMAStrippedByFile["set_vma_name_linux.go"] {
-			panic("runtime stripping rule did not match set_vma_name_linux.go:setVMAName")
-		}
+	if tf.curPkg.ImportPath == "runtime" && flagTiny {
+		validateDirectRuntimeStripping(runtimeStrippedByFile)
 	}
 	if err := saveDebugArtifactsForPkg(tf.curPkg, debugCacheKindCompile, debugArtifacts); err != nil {
 		return nil, err

--- a/transformer.go
+++ b/transformer.go
@@ -810,7 +810,7 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 	flags = flagSetValue(flags, "-p", tf.curPkg.obfuscatedImportPath())
 
 	newPaths := make([]string, 0, len(files))
-	runtimeStrippedByFile := make(map[string]map[string]bool)
+	runtimeVMAStrippedByFile := make(map[string]bool)
 
 	for i, file := range files {
 		basename := filepath.Base(paths[i])
@@ -819,7 +819,7 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 		case "runtime":
 			if flagTiny {
 				// strip unneeded runtime code
-				runtimeStrippedByFile[basename] = stripRuntime(basename, file)
+				runtimeVMAStrippedByFile[basename] = stripRuntime(basename, file)
 				tf.useAllImports(file)
 			}
 			if basename == "symtab.go" {
@@ -856,8 +856,10 @@ func (tf *transformer) transformCompile(args []string) ([]string, error) {
 			debugArtifacts.GarbledFiles[basename] = src
 		}
 	}
-	if tf.curPkg.ImportPath == "runtime" && flagTiny {
-		validateDirectRuntimeStripping(runtimeStrippedByFile)
+	if tf.curPkg.ImportPath == "runtime" && flagTiny && sharedCache.GoEnv.GOOS == "linux" {
+		if !runtimeVMAStrippedByFile["set_vma_name_linux.go"] {
+			panic("runtime stripping rule did not match set_vma_name_linux.go:setVMAName")
+		}
 	}
 	if err := saveDebugArtifactsForPkg(tf.curPkg, debugCacheKindCompile, debugArtifacts); err != nil {
 		return nil, err


### PR DESCRIPTION
On Linux, the runtime gives anonymous mappings diagnostic names such as
`Go: heap arena`. These labels are visible through `/proc/PID/maps` and remain
an OS-visible runtime trace in tiny binaries.

Disable only `setVMAName` for Linux tiny builds and validate that the expected
runtime function was found. Mapping behavior and memory-management metadata are
unchanged.