### PR TITLE
preserve runtime SetTraceback behavior in tiny mode

### DIFF
--- a/runtime_patch.go
+++ b/runtime_patch.go
@@ -183,13 +183,6 @@ func stripRuntime(basename string, file *ast.File) {
 			if funcDecl.Name.Name == "schedtrace" {
 				funcDecl.Body.List = nil
 			}
-		case "runtime1.go":
-			switch funcDecl.Name.Name {
-			case "setTraceback":
-				// tracebacks are completely hidden, no
-				// sense keeping this function
-				funcDecl.Body.List = nil
-			}
 		case "traceback.go":
 			// only used for printing tracebacks
 			switch funcDecl.Name.Name {

--- a/runtime_patch.go
+++ b/runtime_patch.go
@@ -267,12 +267,10 @@ func stripRuntime(basename string, file *ast.File) (strippedFunctions map[string
 				funcDecl.Body.List = nil
 			}
 		case "runtime1.go":
-			switch funcDecl.Name.Name {
-			case "setTraceback":
-				// tracebacks are completely hidden, no
-				// sense keeping this function
-				funcDecl.Body.List = nil
-			}
+			// setTraceback is deliberately left alone. Besides selecting how
+			// much of a traceback is printed, it decides whether fatal errors
+			// crash the process rather than exiting with status 2, and it
+			// enables Windows Error Reporting for GOTRACEBACK=wer.
 		case "runtime.go":
 			// writeErrStr bypasses the print builtins and writes fixed fatal
 			// diagnostics straight to stderr (and SetCrashOutput). Tiny mode

--- a/testdata/script/tiny-wer.txtar
+++ b/testdata/script/tiny-wer.txtar
@@ -1,0 +1,44 @@
+[!windows] skip 'this test checks Windows Error Reporting behavior'
+
+# Tiny mode suppresses traceback output, but runtime/debug.SetTraceback still
+# has non-printing semantics. In particular, "wer" must enable Windows Error
+# Reporting by clearing SEM_NOGPFAULTERRORBOX.
+exec garble -tiny run .
+stderr '^before true$'
+stderr '^after false$'
+
+-- go.mod --
+module test/main
+
+go 1.26
+-- main.go --
+package main
+
+import (
+	"runtime/debug"
+	"syscall"
+)
+
+const semNoGPFaultErrorBox = 0x0002
+
+var (
+	kernel32     = syscall.NewLazyDLL("kernel32.dll")
+	getErrorMode = kernel32.NewProc("GetErrorMode")
+	setErrorMode = kernel32.NewProc("SetErrorMode")
+)
+
+func errorBoxSuppressed() bool {
+	mode, _, _ := getErrorMode.Call()
+	return mode&semNoGPFaultErrorBox != 0
+}
+
+func main() {
+	originalMode, _, _ := getErrorMode.Call()
+	println("before", errorBoxSuppressed())
+	debug.SetTraceback("wer")
+	println("after", errorBoxSuppressed())
+
+	// Avoid changing process behavior after the assertion above.
+	debug.SetTraceback("system")
+	setErrorMode.Call(originalMode)
+}

--- a/testdata/script/tiny.txtar
+++ b/testdata/script/tiny.txtar
@@ -28,6 +28,10 @@ stderr '^makefunc.name reflect\.makeFuncStub value 107$'
 stderr '^methodvalue.name reflect\.methodValueCall value 213$'
 stderr '^wrapper.name _\.\(\*_\)\._ recovered true$'
 stderr '^runtime.sentinels.goexit true gopanic true$'
+# GOTRACEBACK controls more than traceback output, which tiny mode hides:
+# "crash" must still crash the process rather than exit with status 2.
+# TODO: should be "crash aborts: true"; tiny mode empties runtime.setTraceback.
+stderr '^single aborts: false crash aborts: false$'
 
 [short] stop # no need to verify this with -short
 
@@ -48,19 +52,39 @@ stderr '^makefunc.name reflect\.makeFuncStub value 107$'
 stderr '^methodvalue.name reflect\.methodValueCall value 213$'
 stderr '^wrapper.name .* recovered true$'
 stderr '^runtime.sentinels.goexit true gopanic true$'
+stderr '^single aborts: false crash aborts: true$'
 -- go.mod --
 module test/main
 
 go 1.23
+-- main_linux.go --
+package main
+
+import "syscall"
+
+// Keep the crashing children from writing core dumps.
+// Note that syscall.Rlimit is only declared in some unix GOOSes.
+func init() {
+	var lim syscall.Rlimit
+	if syscall.Getrlimit(syscall.RLIMIT_CORE, &lim) == nil {
+		lim.Cur = 0
+		syscall.Setrlimit(syscall.RLIMIT_CORE, &lim)
+	}
+}
 -- garble_main.go --
 package main
 
 import (
 	cryptorand "crypto/rand"
+	"os"
+	"os/exec"
 	"reflect"
 	"runtime"
+	"runtime/debug"
 	"sync"
 )
+
+var nilPtr *int
 
 type testStruct struct{}
 
@@ -156,7 +180,26 @@ func checkRuntimeConsumedNames() {
 	println("runtime.sentinels.goexit", <-goexit, "gopanic", gopanic)
 }
 
+// childAborts reports whether a nil dereference at the given GOTRACEBACK level
+// kills this program rather than exiting with the usual status 2. Only
+// runtime.setTraceback records that setting, so tiny mode must not empty it.
+func childAborts(level string) bool {
+	self, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+	cmd := exec.Command(self, level)
+	cmd.Run()
+	return cmd.ProcessState.ExitCode() != 2
+}
+
 func main() {
+	if len(os.Args) > 1 {
+		debug.SetTraceback(os.Args[1])
+		println(*nilPtr)
+	}
+	println("single aborts:", childAborts("single"), "crash aborts:", childAborts("crash"))
+
 	checkRuntimeConsumedNames()
 
 	// Retain fatal paths which Go 1.26 moved into runtime-linked standard

--- a/testdata/script/tiny.txtar
+++ b/testdata/script/tiny.txtar
@@ -30,8 +30,7 @@ stderr '^wrapper.name _\.\(\*_\)\._ recovered true$'
 stderr '^runtime.sentinels.goexit true gopanic true$'
 # GOTRACEBACK controls more than traceback output, which tiny mode hides:
 # "crash" must still crash the process rather than exit with status 2.
-# TODO: should be "crash aborts: true"; tiny mode empties runtime.setTraceback.
-stderr '^single aborts: false crash aborts: false$'
+stderr '^single aborts: false crash aborts: true$'
 
 [short] stop # no need to verify this with -short
 


### PR DESCRIPTION
Tiny mode empties `runtime.setTraceback`, but the function also updates runtime
state used outside human-readable traceback printing. On Windows that includes
WER crash-reporting behavior.

Stop removing `runtime.setTraceback`. Other tiny traceback-output cleanup is
unchanged.