### PR TITLE
strip tiny source position tables at link time

### DIFF
--- a/internal/linker/patches/go1.26/0005-strip-tiny-source-positions-safely.patch
+++ b/internal/linker/patches/go1.26/0005-strip-tiny-source-positions-safely.patch
@@ -1,0 +1,97 @@
+diff --git a/cmd/link/internal/ld/pcln.go b/cmd/link/internal/ld/pcln.go
+--- a/cmd/link/internal/ld/pcln.go
++++ b/cmd/link/internal/ld/pcln.go
+@@ -195,6 +195,7 @@ func computeDeferReturn(ctxt *Link, deferReturnSym, s loader.Sym) uint32 {
+ // specified FuncInfo.
+ func genInlTreeSym(ctxt *Link, cu *sym.CompilationUnit, fi loader.FuncInfo, arch *sys.Arch, nameOffsets map[loader.Sym]uint32) loader.Sym {
+ 	ldr := ctxt.loader
++	garbleTiny := os.Getenv("GARBLE_LINK_TINY") == "true"
+ 	its := ldr.CreateExtSym("", 0)
+ 	inlTreeSym := ldr.MakeSymbolUpdater(its)
+ 	// Note: the generated symbol is given a type of sym.SGOFUNC, as a
+@@ -217,7 +218,9 @@ func genInlTreeSym(ctxt *Link, cu *sym.CompilationUnit, fi loader.FuncInfo, arch
+ 		startLine := int32(0)
+ 		if inlFunc.Valid() {
+ 			funcID = inlFunc.FuncID()
+-			startLine = inlFunc.StartLine()
++			if !garbleTiny {
++				startLine = inlFunc.StartLine()
++			}
+ 		} else if !ctxt.linkShared {
+ 			// Inlined functions are always Go functions, and thus
+ 			// must have FuncInfo.
+@@ -442,6 +445,19 @@ func walkFilenames(ctxt *Link, funcs []loader.Sym, f func(*sym.CompilationUnit,
+ //  2. Find filename offset:   fileOffset := runtime.cutab[M+K]
+ //  3. Get the filename:       getcstring(runtime.filetab[fileOffset])
+ func (state *pclntab) generateFilenameTabs(ctxt *Link, compUnits []*sym.CompilationUnit, funcs []loader.Sym) []uint32 {
++	if os.Getenv("GARBLE_LINK_TINY") == "true" {
++		// Keep non-empty placeholder symbols so pcHeader offsets and moduledata
++		// layout remain valid, but do not copy any source filenames or CU tables.
++		state.cutab = state.addGeneratedSym(ctxt, "runtime.cutab", 4, 4, func(ctxt *Link, s loader.Sym) {
++			ctxt.loader.MakeSymbolUpdater(s).SetUint32(ctxt.Arch, 0, ^uint32(0))
++		})
++		state.filetab = state.addGeneratedSym(ctxt, "runtime.filetab", 2, 1, func(ctxt *Link, s loader.Sym) {
++			ctxt.loader.MakeSymbolUpdater(s).AddCStringAt(0, "?")
++		})
++		state.nfiles = 0
++		return make([]uint32, len(compUnits))
++	}
++
+ 	// On a per-CU basis, keep track of all the filenames we need.
+ 	//
+ 	// Note, that we store the filenames in a separate section in the object
+@@ -528,6 +544,7 @@ func (state *pclntab) generateFilenameTabs(ctxt *Link, compUnits []*sym.Compilat
+ // deduplicated pcdata.
+ func (state *pclntab) generatePctab(ctxt *Link, funcs []loader.Sym) {
+ 	ldr := ctxt.loader
++	garbleTiny := os.Getenv("GARBLE_LINK_TINY") == "true"
+ 
+ 	// Pctab offsets of 0 are considered invalid in the runtime. We respect
+ 	// that by just padding a single byte at the beginning of runtime.pctab,
+@@ -559,7 +576,10 @@ func (state *pclntab) generatePctab(ctxt *Link, funcs []loader.Sym) {
+ 		fi.Preload()
+ 		pcsp, pcfile, pcline, pcinline, pcdata = ldr.PcdataAuxs(s, pcdata)
+ 
+-		pcSyms := []loader.Sym{pcsp, pcfile, pcline}
++		pcSyms := []loader.Sym{pcsp}
++		if !garbleTiny {
++			pcSyms = append(pcSyms, pcfile, pcline)
++		}
+ 		for _, pcSym := range pcSyms {
+ 			saveOffset(pcSym)
+ 		}
+@@ -874,6 +894,7 @@ func writePCToFunc(ctxt *Link, sb *loader.SymbolBuilder, funcs []loader.Sym, sta
+ // writeFuncs writes the func structures and pcdata to runtime.functab.
+ func writeFuncs(ctxt *Link, sb *loader.SymbolBuilder, funcs []loader.Sym, inlSyms map[loader.Sym]loader.Sym, startLocations, cuOffsets []uint32, nameOffsets map[loader.Sym]uint32) {
+ 	ldr := ctxt.loader
++	garbleTiny := os.Getenv("GARBLE_LINK_TINY") == "true"
+ 	deferReturnSym := ldr.Lookup("runtime.deferreturn", abiInternalVer)
+ 	textStart := ldr.SymValue(ldr.Lookup("runtime.text", 0))
+ 	funcdata := []loader.Sym{}
+@@ -887,7 +908,9 @@ func writeFuncs(ctxt *Link, sb *loader.SymbolBuilder, funcs []loader.Sym, inlSym
+ 		if fi.Valid() {
+ 			fi.Preload()
+ 			pcsp, pcfile, pcline, pcinline, pcdata = ldr.PcdataAuxs(s, pcdata)
+-			startLine = fi.StartLine()
++			if !garbleTiny {
++				startLine = fi.StartLine()
++			}
+ 		}
+ 
+ 		off := int64(startLocations[i])
+@@ -917,8 +940,13 @@ func writeFuncs(ctxt *Link, sb *loader.SymbolBuilder, funcs []loader.Sym, inlSym
+ 		// pcdata
+ 		if fi.Valid() {
+ 			off = sb.SetUint32(ctxt.Arch, off, uint32(ldr.SymValue(pcsp)))
+-			off = sb.SetUint32(ctxt.Arch, off, uint32(ldr.SymValue(pcfile)))
+-			off = sb.SetUint32(ctxt.Arch, off, uint32(ldr.SymValue(pcline)))
++			if garbleTiny {
++				off = sb.SetUint32(ctxt.Arch, off, 0)
++				off = sb.SetUint32(ctxt.Arch, off, 0)
++			} else {
++				off = sb.SetUint32(ctxt.Arch, off, uint32(ldr.SymValue(pcfile)))
++				off = sb.SetUint32(ctxt.Arch, off, uint32(ldr.SymValue(pcline)))
++			}
+ 		} else {
+ 			off += 12
+ 		}

--- a/testdata/script/tiny.txtar
+++ b/testdata/script/tiny.txtar
@@ -3,9 +3,11 @@ exec garble -tiny build
 ! binsubstr main$exe 'garble_main.go' 'fmt/print.go'
 ! exec ./main$exe
 stderr '^\(0x[[:xdigit:]]+,0x[[:xdigit:]]+\)' # interfaces/pointers print correctly
-# With -tiny, all line numbers are reset to 1.
-# Unfortunately, line comment directives don't allow erasing line numbers entirely.
-stderr '^caller: \?\? 1$' # position info is removed
+# Tiny binaries have no Go source-file or source-line mappings.
+stderr '^caller: \? 0$'
+stderr '^funcline.local: \? 0$'
+stderr '^funcline.stdlib: \? 0$'
+stderr '^callersframes.removed true$'
 stderr '^recovered: ya like jazz?'
 ! stderr 'panic: oh noes' # panics are hidden
 stderr 'funcExported false funcUnexported true'
@@ -16,7 +18,10 @@ stderr 'funcStructExported false funcStructUnexported true'
 # Default mode
 exec garble build
 ! exec ./main$exe
-stderr '^caller: [[:word:]]+\.go [1-9]'
+stderr '^caller: [^[:space:]]+ [1-9][0-9]*$'
+stderr '^funcline.local: [^[:space:]]+ [1-9][0-9]*$'
+stderr '^funcline.stdlib: [^[:space:]]+ [1-9][0-9]*$'
+stderr '^callersframes.removed false$'
 stderr '^recovered: ya like jazz?'
 stderr 'panic: oh noes'
 stderr 'funcExported false funcUnexported false'
@@ -48,6 +53,35 @@ func isEmptyFuncName(i interface{}) bool {
 	return len(name) == 0
 }
 
+//go:noinline
+func printPositionInfo() {
+	pc, file, line, _ := runtime.Caller(0)
+	println("caller:", file, line)
+
+	localFunc := runtime.FuncForPC(pc)
+	file, line = localFunc.FileLine(localFunc.Entry())
+	println("funcline.local:", file, line)
+
+	stdlibFunc := runtime.FuncForPC(reflect.ValueOf(runtime.GOMAXPROCS).Pointer())
+	file, line = stdlibFunc.FileLine(stdlibFunc.Entry())
+	println("funcline.stdlib:", file, line)
+
+	pcs := make([]uintptr, 32)
+	n := runtime.Callers(0, pcs)
+	frames := runtime.CallersFrames(pcs[:n])
+	allRemoved := n > 0
+	for {
+		frame, more := frames.Next()
+		if frame.File != "?" || frame.Line != 0 {
+			allRemoved = false
+		}
+		if !more {
+			break
+		}
+	}
+	println("callersframes.removed", allRemoved)
+}
+
 func main() {
 	println("funcExported", isEmptyFuncName(ExportedFunc), "funcUnexported", isEmptyFuncName(unexportedFunc))
 
@@ -64,8 +98,7 @@ func main() {
 		}
 	}()
 
-	_, file, line, _ := runtime.Caller(0)
-	println("caller:", file, line)
+	printPositionInfo()
 
 	panic("ya like jazz?")
 }


### PR DESCRIPTION
Tiny currently rewrites source positions but still retains filename/line
tables. The binary therefore keeps metadata that tiny mode intends to remove.

Remove final filename and line mappings in the linker while retaining stack
maps, `pcsp`, `pcinline`, unwind data, and other execution-critical metadata.