### PR TITLE
include WASI when generating runtime dependency tables

### DIFF
--- a/go_std_tables.go
+++ b/go_std_tables.go
@@ -37,6 +37,7 @@ var runtimeAndDeps = map[string]bool{
 	"internal/trace/tracev2":           true, // go1.26 linux/amd64
 	"math/bits":                        true, // go1.26 linux/amd64
 	"runtime":                          true, // go1.26 linux/amd64
+	"structs":                          true, // go1.26 wasip1/wasm
 	"unsafe":                           true, // go1.26 linux/amd64
 }
 

--- a/scripts/gen_go_std_tables.go
+++ b/scripts/gen_go_std_tables.go
@@ -30,12 +30,14 @@ func (p goPlatform) String() string {
 	return fmt.Sprintf("%s/%s", p.GOOS, p.GOARCH)
 }
 
-// Cover the three main OSes and a variety of x86/Arm and 64/32 bit platforms
-// when calling `go list` commands to ensure we find all relevant packages.
+// Cover the three main OSes, WASI, and a variety of x86/Arm and 64/32 bit
+// platforms when calling `go list` commands to ensure we find all relevant
+// packages.
 var goPlatforms = []goPlatform{
 	{"linux", "amd64", 1},
 	{"darwin", "arm64", 2},
 	{"windows", "386", 3},
+	{"wasip1", "wasm", 4},
 }
 var goVersions = []string{"go1.26.1"}
 

--- a/testdata/script/crossbuild.txtar
+++ b/testdata/script/crossbuild.txtar
@@ -18,14 +18,19 @@
 exec garble build -gcflags=math/bits=-d=ssa/intrinsics/debug=1
 stderr 'intrinsic substitution for ReverseBytes32.*Bswap32'
 
-# As a last step, also test building for MacOS if we're not already on it.
+# Also test building for MacOS if we're not already on it.
 # We already cover Windows and Linux above, and MacOS is the other major OS.
 # The way it is implemented in the standard library, in particular with syscalls,
 # is different enough that it sometimes causes special bugs.
-[darwin] stop
-env GOOS=darwin
-env GOARCH=arm64
-exec garble build
+[!darwin] env GOOS=darwin
+[!darwin] env GOARCH=arm64
+[!darwin] exec garble build
+
+# WASI's runtime uniquely imports package structs for HostLayout markers in
+# go:wasmimport signatures. Keep that runtime dependency unobfuscated.
+env GOOS=wasip1
+env GOARCH=wasm
+exec garble -tiny build
 
 -- go.mod --
 module test/main


### PR DESCRIPTION
The generated standard-library dependency table does not include the
`wasip1/wasm` target. Tiny cross-builds can therefore miss target-specific
runtime dependencies such as `structs.HostLayout`.

Generate and embed dependency data for WASI, and cover it in the cross-build
script.