### PR TITLE
don't pick generic type aliases for import references

### DIFF
--- a/testdata/script/typeparams.txtar
+++ b/testdata/script/typeparams.txtar
@@ -1,13 +1,23 @@
 exec garble build
-! binsubstr main$exe ${WORK} 'garble_main.go' 'GenericFunc' 'GenericVector' 'PredeclaredSignedInteger' 'StringableSignedInteger' 'CombineEmbeds' 'GenericParam'
+! binsubstr main$exe ${WORK} 'garble_main.go' 'GenericFunc' 'GenericVector' 'PredeclaredSignedInteger' 'StringableSignedInteger' 'CombineEmbeds' 'GenericParam' 'GenAlias'
+
+# Literal obfuscation adds import references via useAllImports;
+# aliaslib exports only generic types, which are not valid for an
+# uninstantiated "var _ pkg.Name" reference.
+exec garble -literals build
 -- go.mod --
 module test/main
 
-go 1.23
+go 1.24
 -- garble_main.go --
 package main
 
-import "test/main/lib"
+import (
+	"test/main/aliaslib"
+	"test/main/lib"
+)
+
+var _ aliaslib.GenAlias[int]
 
 func main() {
 	GenericFunc[int, int](1, 2)
@@ -110,6 +120,10 @@ func byKeys[T any](m map[string]T) []struct {
 }
 
 var _ = byKeys(map[string]int{"one": 1})
+-- aliaslib/aliaslib.go --
+package aliaslib
+
+type GenAlias[T any] = func(T)
 -- lib/lib.go --
 package lib
 

--- a/transformer.go
+++ b/transformer.go
@@ -193,8 +193,13 @@ func recordFieldToStruct(typ types.Type, done map[*types.Named]bool, fieldToStru
 }
 
 // isSafeForInstanceType returns true if the passed type is safe for var declaration.
-// Unsafe types: generic types and non-method interfaces.
+// Unsafe types: generic types, generic type aliases, and non-method interfaces.
 func isSafeForInstanceType(t types.Type) bool {
+	// A generic alias cannot be used without instantiation,
+	// and types.Unalias below would hide its type parameters.
+	if alias, ok := t.(*types.Alias); ok && alias.TypeParams().Len() > 0 {
+		return false
+	}
 	switch t := types.Unalias(t).(type) {
 	case *types.Basic:
 		return t.Kind() != types.Invalid


### PR DESCRIPTION
useAllImports keeps imports alive by referencing an arbitrary exported symbol via "var _ pkg.Name". isSafeForInstanceType resolved aliases with types.Unalias before checking type parameters, so a parameterized alias whose right-hand side is a plain function type, such as

```
type Option[T any] = func(T) error
```

was considered safe, producing `var _ pkg.Option`, which fails to compile with "cannot use generic type ... without instantiation". Whether the bug triggered depended on the obfuscated name ordering, so builds failed or passed depending on the seed.

Check the alias's own type parameters before unaliasing.