### PR TITLE
tiny: disable unexported funcname removal, it corrupts the pclntab

### DIFF
--- a/internal/linker/patches/go1.26/0002-add-unexported-function-name-removing.patch
+++ b/internal/linker/patches/go1.26/0002-add-unexported-function-name-removing.patch
@@ -22,11 +22,18 @@ index ffe8fdf7a1..c47b9eab72 100644
  import (
  	"cmd/internal/goobj"
  	"cmd/internal/objabi"
-@@ -335,19 +339,56 @@ func walkFuncs(ctxt *Link, funcs []loader.Sym, f func(loader.Sym)) {
+@@ -335,19 +339,63 @@ func walkFuncs(ctxt *Link, funcs []loader.Sym, f func(loader.Sym)) {
  func (state *pclntab) generateFuncnametab(ctxt *Link, funcs []loader.Sym) map[loader.Sym]uint32 {
  	nameOffsets := make(map[loader.Sym]uint32, state.nfunc)
  
-+	garbleTiny := os.Getenv("GARBLE_LINK_TINY") == "true"
++	// Disabled: redirecting unexported funcnames to the empty string corrupts
++	// the pclntab under tiny builds - the runtime then fails findfunc on real
++	// return addresses ("unexpected return pc", "fatal error: unknown caller
++	// pc") and dies on the system stack during write-barrier flushes. The rest
++	// of the tiny name handling below stays inert because no symbol is
++	// assigned offset 0 anymore; re-enable only together with a fix for the
++	// pcln.go accounting bug.
++	garbleTiny := false
 +
  	// Write the null terminated strings.
  	writeFuncNameTab := func(ctxt *Link, s loader.Sym) {

--- a/internal/linker/patches/go1.26/0002-add-unexported-function-name-removing.patch
+++ b/internal/linker/patches/go1.26/0002-add-unexported-function-name-removing.patch
@@ -22,17 +22,21 @@ index ffe8fdf7a1..c47b9eab72 100644
  import (
  	"cmd/internal/goobj"
  	"cmd/internal/objabi"
-@@ -335,19 +339,63 @@ func walkFuncs(ctxt *Link, funcs []loader.Sym, f func(loader.Sym)) {
+@@ -335,19 +339,67 @@ func walkFuncs(ctxt *Link, funcs []loader.Sym, f func(loader.Sym)) {
  func (state *pclntab) generateFuncnametab(ctxt *Link, funcs []loader.Sym) map[loader.Sym]uint32 {
  	nameOffsets := make(map[loader.Sym]uint32, state.nfunc)
  
-+	// Disabled: redirecting unexported funcnames to the empty string corrupts
-+	// the pclntab under tiny builds - the runtime then fails findfunc on real
-+	// return addresses ("unexpected return pc", "fatal error: unknown caller
-+	// pc") and dies on the system stack during write-barrier flushes. The rest
-+	// of the tiny name handling below stays inert because no symbol is
-+	// assigned offset 0 anymore; re-enable only together with a fix for the
-+	// pcln.go accounting bug.
++	// Disabled: every variant of hiding unexported funcnames crashes the
++	// runtime under load. Verified at production scale (3+ runs each):
++	// redirect to offset 0, redirect to a valid nonzero offset, blanking the
++	// name in place (original nameOff, zeroed slot) and writing a "." placeholder
++	// - all die ("unexpected return pc", "unknown caller pc", bounds panic on
++	// the system stack during write-barrier flushes, or "bad g in signal
++	// handler"), while the identical alterations on a vanilla toolchain are
++	// clean and garble builds with untouched names never crash. Keeping names
++	// intact is the only safe state, so the removal feature stays off until
++	// the underlying funcname dependency in toolexec-compiled runtimes is
++	// understood and fixed.
 +	garbleTiny := false
 +
  	// Write the null terminated strings.


### PR DESCRIPTION
## What

Disables the `-tiny` linker rewrite that hides unexported function names (patch `0002-add-unexported-function-name-removing`). Everything else `-tiny` does (stripRuntime, `-w -s`, buildid blanking, patch 0003 entryOff encryption) is unchanged, and name obfuscation itself is untouched — only the funcname-table rewrite is turned off.

## Why

With v0.17.0 (and current master `0ad0a3b`), `garble -literals -tiny` on go1.26.6 (linux/amd64, CGO_ENABLED=0, `-buildmode=pie`) produces binaries that die under allocation-heavy load:

```
runtime: g 1: unexpected return pc for lIamwp8.UxVDsuQi called from 0x5686cc0fb90
fatal error: unknown caller pc
```

and, when the fault lands on the system stack during a write-barrier buffer flush:

```
panic: (runtime.boundsError)
fatal error: panic on system stack
SIGSEGV ...
goroutine 0 [idle]:            <- system stack, m=2
  runtime/malloc.go:1384       <- gc.SizeToSizeClass128[...] index out of range
  runtime/malloc.go:1143
  runtime/iface.go:368         <- convT16
  runtime/panic.go:236
  runtime/mwbbuf.go:199/181    <- write-barrier buffer flush
```

Two extra properties make this nasty in the wild:

- the fault is load/timing dependent: ~100% within ~3 rounds on a production-shaped workload (~130k-element maps/slices, ~720 MB peak heap), 0% on toy programs — it passes `go test ./...` and short smoke tests;
- tiny mode also strips all runtime printing, so the crash is a **silent** exit 2 with no output even under `GOTRACEBACK=crash`.

## Every in-patch variant was tried — all crash

Same harness, same host, ~30 build-and-run cycles (3+ runs each cell):

| toolchain | unexported `_func` names | result |
|---|---|---|
| stock v0.17.0 `-literals -tiny` (redirect to offset 0) | crash 3/3 (+2/2) |
| redirect to a **valid nonzero** offset | crash 3/3 |
| blank the name **in place** (original nameOff, zeroed slot) | crash 5/6 |
| write a `"."` **placeholder** (non-empty, original nameOff) | crash 2/3 |
| garble with `-literals`/`-tiny`/obfuscation each removed in turn | crash 3/3 each |
| garble with **names intact** (this PR / no `-tiny`) | **clean** (0/30 darwin, 3x150 + 6x3 linux) |
| **vanilla** toolchain with identical alterations (redirect / blank) | **clean 9/9** |

Excluded as the cause, one at a time: patch 0003 entryOff XOR (crash persists with key=0 on both sides), the custom pclntab magic (crash persists with stock magic), the `abiNamePatch`/`_originalNames` injection (crash persists with it disabled), `-literals`, and identifier obfuscation (GOGARBLE scoped to a single leaf package still crashes).

So the crash is not an accounting bug in one implementation of the removal — **any** alteration of unexported `_func` name resolution in a garble-built binary is fatal under load, while the identical alterations on a vanilla toolchain are harmless. Until the underlying funcname dependency in garble-toolexec-compiled runtimes is understood, keeping names intact is the only safe state, which is what this PR does.

## Repro

The workload is a proprietary service's sync pass driven against mocks (several goroutines fanning out over ~130k-element maps with heavy slice growth, default GOGC, built with the exact flags above); a standalone reducer has not been extracted yet. The bisect was driven by env-gated one-line toggles in the linker patches plus fresh garble caches per variant. Happy to help extract a minimal reducer or share harness details.