### PR TITLE
internal/literals: don't obfuscate inside constant expressions

### DIFF
--- a/internal/literals/literals.go
+++ b/internal/literals/literals.go
@@ -68,6 +68,32 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 					return false
 				}
 			}
+
+		case ast.Expr:
+			// The compiler folds constant expressions, so only the outermost
+			// one exists at run time. Rewrite that one and stop descending,
+			// rather than also rewriting its operands into dead decoders.
+			typeAndValue := info.Types[node]
+			if typeAndValue.Value == nil {
+				break
+			}
+			if typeAndValue.Value.Kind() != constant.String {
+				// Constants of other kinds, such as len or unsafe.Sizeof, do
+				// not evaluate their operands at all. Rewriting them would be
+				// useless, and would stop uses which require a constant, such
+				// as array lengths or keyed indexes, from compiling.
+				return false
+			}
+			if typeAndValue.Type == types.Typ[types.String] {
+				value := constant.StringVal(typeAndValue.Value)
+				if len(value) >= MinSize && len(value) <= MaxSize {
+					cursor.Replace(withPos(obfuscateString(or, value), node.Pos()))
+					return false
+				}
+			}
+			// Keep descending: a string constant we left alone, such as one
+			// above MaxSize or one of a named type, may still have operands
+			// which we can rewrite.
 		}
 		return true
 	}
@@ -80,17 +106,6 @@ func Obfuscate(rand *mathrand.Rand, file *ast.File, info *types.Info, linkString
 
 		typeAndValue := info.Types[node]
 		if !typeAndValue.IsValue() {
-			return true
-		}
-
-		if typeAndValue.Type == types.Typ[types.String] && typeAndValue.Value != nil {
-			value := constant.StringVal(typeAndValue.Value)
-			if len(value) < MinSize || len(value) > MaxSize {
-				return true
-			}
-
-			cursor.Replace(withPos(obfuscateString(or, value), node.Pos()))
-
 			return true
 		}
 

--- a/testdata/script/literals.txtar
+++ b/testdata/script/literals.txtar
@@ -3,7 +3,7 @@ exec ./main$exe
 cmp stderr main.stderr
 
 binsubstr main$exe 'skip typed const' 'skip typed var' 'skip typed var assign' 'stringTypeField strType' 'stringType lambda func return' 'testMap2 key' 'testMap3 key' 'testMap1 value' 'testMap3 value' 'testMap1 new value' 'testMap3 new value' 'stringType func param' 'stringType return' 'skip untyped const' 'sz<min'
-! binsubstr main$exe 'garbleDecrypt' 'Lorem Ipsum' 'dolor sit amet' 'first assign' 'second assign' 'First Line' 'Second Line' 'secret map value' 'obfuscated with shadowed builtins' '1: literal in' 'an secret array' '2: literal in' 'a secret slice' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 'testMap1 key' 'Obfuscate this block' 'also obfuscate this'
+! binsubstr main$exe 'garbleDecrypt' 'Lorem Ipsum' 'dolor sit amet' 'first assign' 'second assign' 'First Line' 'Second Line' 'secret map value' 'obfuscated with shadowed builtins' '1: literal in' 'an secret array' '2: literal in' 'a secret slice' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 'testMap1 key' 'Obfuscate this block' 'also obfuscate this' 'oversize concat secret'
 
 [short] stop # checking that the build is reproducible is slow
 
@@ -17,7 +17,7 @@ bincmp main$exe main_old$exe
 go build
 exec ./main$exe
 cmp stderr main.stderr
-binsubstr main$exe 'Lorem Ipsum' 'dolor sit amet' 'second assign' 'First Line' 'Second Line' 'secret map value' 'obfuscated with shadowed builtins' '1: literal in' 'an secret array' '2: literal in' 'a secret slice' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 'testMap1 key' 'Obfuscate this block' 'also obfuscate this'
+binsubstr main$exe 'Lorem Ipsum' 'dolor sit amet' 'second assign' 'First Line' 'Second Line' 'secret map value' 'obfuscated with shadowed builtins' '1: literal in' 'an secret array' '2: literal in' 'a secret slice' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 'testMap1 key' 'Obfuscate this block' 'also obfuscate this' 'oversize concat secret'
 
 # Generate and write random literals into a separate file.
 # Some of them will be huge; assuming that we don't try to obfuscate them, the
@@ -89,6 +89,22 @@ var array [arrayLen]byte
 
 type typeAlias [arrayLen]byte
 
+// Strings which are only used inside constant expressions must be left alone;
+// rewriting them into decoder calls would stop the constants from compiling.
+const constString string = "constant expression secret"
+
+type constStringAlias string
+
+var constLen [len(constString)]byte
+var constConversion [len(constStringAlias(constString))]byte
+var constKeyed = [len(constString)]byte{len(constString) - 1: 1}
+var constArrayLen [len([8]byte{1, 2, 3, 4, 5, 6, 7, 8})]byte
+var constArrayCap [cap(&[8]byte{1, 2, 3, 4, 5, 6, 7, 8})]byte
+
+// Padding to push the concatenation in main above MaxSize.
+const padding512 = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+const padding2048 = padding512 + padding512 + padding512 + padding512
+
 func main() {
 	empty := ""
 	tooSmall := "sz<min"
@@ -99,9 +115,13 @@ func main() {
 	reassign = "second assign"
 
 	add := "totally long" + "unnecessarily added string"
+	// The concatenation is above MaxSize so it is left alone, but its typed
+	// operand below MaxSize must still be obfuscated.
+	oversize := string("oversize concat secret") + padding2048
 
 	println(cnst, boolean)
 	println(multiline, add)
+	println(oversize[:22])
 	println(localVar)
 	println(reassign)
 	println(empty)
@@ -125,6 +145,7 @@ func main() {
 	println("another literal")
 	println(mixedBlock, iotaBlock)
 	println(i, foo, bar)
+	println(len(constLen), len(constConversion), len(constKeyed), len(constArrayLen), len(constArrayCap))
 	typedTest()
 	constantTest()
 	byteTest()
@@ -459,6 +480,7 @@ func str9() { println("foo bar bar") }
 Lorem Ipsum true
 First Line
 Second Line totally longunnecessarily added string
+oversize concat secret
 dolor sit amet
 second assign
 
@@ -469,6 +491,7 @@ secret new value
 another literal
 Obfuscate this block also obfuscate this
 1 0 1
+26 26 26 8 8
 skip untyped const
 skip typed const skip typed var skip typed var assign
 stringTypeField String stringTypeField strType


### PR DESCRIPTION
(see commit message)

