### PR TITLE
strip the native build ID when linking externally

### DIFF
--- a/testdata/script/cgo.txtar
+++ b/testdata/script/cgo.txtar
@@ -6,6 +6,10 @@ exec ./main
 cmp stdout main.stdout
 ! binsubstr main$exe 'PortedField' 'test/main'
 
+# Linking externally must not leave the C toolchain's build ID behind either.
+[linux] [exec:readelf] exec readelf --wide --section-headers main$exe
+[linux] [exec:readelf] ! stdout '\.note\.gnu\.build-id'
+
 [short] stop # no need to verify this with -short
 
 # Ensure that reversing works with cgo.

--- a/transformer.go
+++ b/transformer.go
@@ -1535,6 +1535,15 @@ func (tf *transformer) transformLink(args []string) ([]string, error) {
 	// link operation or the main package's compilation.
 	flags = flagSetValue(flags, "-buildid", "")
 
+	// Clearing Go's build ID is not enough when linking externally,
+	// as the C toolchain adds one of its own, such as ELF's
+	// .note.gnu.build-id. -B=none asks cmd/link for no native build ID.
+	// macOS is the exception, as its dynamic linker refuses to load
+	// binaries which lack an LC_UUID load command.
+	if sharedCache.GoEnv.GOOS != "darwin" {
+		flags = append(flags, "-B=none")
+	}
+
 	// Strip debug information and symbol tables.
 	flags = append(flags, "-w", "-s")
 


### PR DESCRIPTION
(see commit message)

