### PR TITLE
add install to wrap "go install"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@
 # Please keep the list sorted.
 
 Andrew LeFevre <jalefevre@liberty.edu>
+Chris (ChrisJr404) <11917633+ChrisJr404@users.noreply.github.com>
 Daniel Martí <mvdan@mvdan.cc>
 Emmanuel Chee-zaram Okeke <ecokeke21@gmail.com>
 Golo Roden <golo.roden@thenativeweb.io>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Obfuscate Go code by wrapping the Go toolchain. Requires Go 1.27 or later.
 
 The tool also supports `garble test` to run tests with obfuscated code,
 `garble run` to obfuscate and execute simple programs,
+`garble install` to build and install obfuscated binaries,
 `garble reverse` to de-obfuscate text such as stack traces,
 and `garble bug` to file a pre-filled bug report.
 Run `garble -h` to see all available commands and flags.

--- a/main.go
+++ b/main.go
@@ -241,7 +241,7 @@ func mainErr(args []string) error {
 		return commandMap(args)
 	case "bug":
 		return commandBug(args)
-	case "build", "test", "run":
+	case "build", "test", "run", "install":
 		cmd, err := toolexecCmd(command, args)
 		defer func() {
 			if err := os.RemoveAll(os.Getenv("GARBLE_SHARED")); err != nil {
@@ -666,6 +666,7 @@ The following commands are supported:
 	build          replace "go build"
 	test           replace "go test"
 	run            replace "go run"
+	install        replace "go install"
 	reverse        de-obfuscate output such as stack traces
 	map            describe how names are obfuscated, as JSON
 	bug            start a bug report

--- a/testdata/script/help.txtar
+++ b/testdata/script/help.txtar
@@ -39,6 +39,14 @@ stderr 'Run .go help test.'
 ! stderr 'Garble obfuscates Go code'
 ! stdout .
 
+! exec garble install -h
+stderr 'garble \[garble flags\] install'
+stderr 'This command wraps "go install"'
+stderr 'usage: go install'
+stderr 'Run .go help install.'
+! stderr 'Garble obfuscates Go code'
+! stdout .
+
 ! exec garble reverse -h
 stderr 'garble \[garble flags\] reverse \[build flags\] package \[files\]'
 ! stderr 'usage: go '

--- a/testdata/script/install.txtar
+++ b/testdata/script/install.txtar
@@ -1,0 +1,30 @@
+# Check that "garble install" builds and installs an obfuscated binary.
+env GOBIN=$WORK/bin
+exec garble install .
+exists $WORK/bin/main$exe
+
+# The installed binary works and is obfuscated.
+exec $WORK/bin/main$exe
+stdout '^hello from garble install$'
+! binsubstr $WORK/bin/main$exe ${WORK} 'garble_main.go' 'greeting' 'test/main'
+
+[short] stop # installing a second time to check caching is slow
+
+# Installing again reuses the build cache and produces the same binary.
+cp $WORK/bin/main$exe $WORK/bin/main_old$exe
+rm $WORK/bin/main$exe
+exec garble install .
+bincmp $WORK/bin/main$exe $WORK/bin/main_old$exe
+
+-- go.mod --
+module test/main
+
+go 1.23
+-- garble_main.go --
+package main
+
+import "fmt"
+
+func greeting() string { return "hello from garble install" }
+
+func main() { fmt.Println(greeting()) }


### PR DESCRIPTION
Adds a `garble install` command, as requested in #981.

It goes through the same toolexec path as build, test and run, since `go install` builds packages the same way, so there was nothing install-specific to handle. Now you can obfuscate and install in one step instead of running `garble build` and moving the binary into GOBIN yourself.

Added a testscript that installs into a temporary GOBIN, checks the binary runs and is obfuscated, and confirms a second install reuses the cache. Also extended the help test for `garble install -h`.